### PR TITLE
Parsed file ressources are not freed

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -82,13 +82,18 @@ public class RobotParser {
 				if(dirFromFileGLOB != null)
 					baseDirectory = new File(baseDirectory, dirFromFileGLOB.toString());
 				
+				FileReader reportReader = new FileReader(reportFile);
 				try {
 					XMLStreamReader reader = factory.createXMLStreamReader(
-							new FileReader(reportFile));
+							reportReader);
 					result =  parseResult(reader, baseDirectory);
 				} catch (XMLStreamException e1) {
 					throw new IOException("Parsing of output xml failed!", e1);
+				} finally {
+					reportReader.close();
+					reportReader = null;
 				}
+					
 			}
 			return result;
 		}


### PR DESCRIPTION
When parsing a Robot Framework result file, the plugin doesn't explicitely close that file when done which may lead to file handles never being released.
