### PR TITLE
[FIXED JENKINS-21739] links to Robot Framework files are now valid for jobs residing inside folders

### DIFF
--- a/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
+++ b/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
@@ -76,15 +76,12 @@ limitations under the License.
   	</tr>
   </table>
   <p>
-  <j:if test="${attrs.action.owner.project.parent.name != null}">
-    <j:set var="matrixprojectname" value="${attrs.action.owner.project.parent.name}/" />
-  </j:if>
-  <a href="${rootURL}/job/${matrixprojectname}${attrs.action.owner.project.name}/${attrs.action.owner.number}/${attrs.action.urlName}">&gt; Browse results</a><br />
+  <a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}">&gt; Browse results</a><br />
   <j:if test="${attrs.action.logFileLink != null}">
-  	<a href="${rootURL}/job/${matrixprojectname}${attrs.action.owner.project.name}/${attrs.action.owner.number}/${attrs.action.urlName}/report/${attrs.action.logFileLink}">&gt; Open ${attrs.action.logFileLink}</a><br />
+  	<a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}/report/${attrs.action.logFileLink}">&gt; Open ${attrs.action.logFileLink}</a><br />
   </j:if>
   <j:if test="${attrs.action.logHtmlLink != null}">
-  	<a href="${rootURL}/job/${matrixprojectname}${attrs.action.owner.project.name}/${attrs.action.owner.number}/${attrs.action.urlName}/report/${attrs.action.logHtmlLink}">&gt; Open ${attrs.action.logHtmlLink}</a><br />
+  	<a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}/report/${attrs.action.logHtmlLink}">&gt; Open ${attrs.action.logHtmlLink}</a><br />
   </j:if>
   </p>
 </j:jelly>


### PR DESCRIPTION
Links to robot framework report files were invalid (404) when the job was inside a folder (from CloudBees Folder plugin).

For example, instead of:
/job/my_folder/my_job/3446/robot/report/report.html
... we should get:
/job/my_folder/job/my_job/3446/robot/report/report.html

This very simple fix works for all kinds of jobs, given Run.getUrl() provides the right path we need: verified with trivial job, matrix axis, item within a folder. All tests pass.

Could you please consider applying it to the main branch?
