### PR TITLE
JENKINS-26980 - Enable configuration of "Robot Results" column in the default job list view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version><!-- which version of Hudson is this plugin built against? -->
+    <version>1.447</version><!-- which version of Hudson is this plugin built against? -->
   </parent>
 
   <artifactId>robot</artifactId>

--- a/src/main/java/hudson/plugins/robot/RobotConfig.java
+++ b/src/main/java/hudson/plugins/robot/RobotConfig.java
@@ -1,0 +1,35 @@
+package hudson.plugins.robot;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class RobotConfig extends GlobalConfiguration {
+
+	private boolean robotResultsColumnEnabled = true;
+
+	public RobotConfig() {
+		load();
+	}
+
+	@Override
+	public boolean configure(StaplerRequest req, JSONObject o) throws FormException {
+		// Get Robot Framework section
+		o = o.getJSONObject("robotFramework");
+
+		robotResultsColumnEnabled = o.getBoolean("robotResultsColumnEnabled");
+
+		save();
+		return super.configure(req, o);
+	}
+
+	public boolean isRobotResultsColumnEnabled() {
+		return robotResultsColumnEnabled;
+	}
+
+	public void setRobotResultsColumnEnabled(boolean robotResultsColumnEnabled) {
+		this.robotResultsColumnEnabled = robotResultsColumnEnabled;
+	}
+}

--- a/src/main/java/hudson/plugins/robot/view/RobotListViewColumn.java
+++ b/src/main/java/hudson/plugins/robot/view/RobotListViewColumn.java
@@ -5,22 +5,25 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.plugins.robot.RobotBuildAction;
+import hudson.plugins.robot.RobotConfig;
 import hudson.plugins.robot.model.RobotResult;
 import hudson.views.ListViewColumn;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.inject.Inject;
 
 public class RobotListViewColumn extends ListViewColumn {
 
 	@DataBoundConstructor
 	public RobotListViewColumn(){
 	}
-	
+
 	@Override
 	public String getColumnCaption() {
         return getDescriptor().getDisplayName();
     }
-	
+
 	public long getPass(Job job){
 		RobotResult lastRobotResult = getLastRobotResult(job);
 		if(lastRobotResult != null){
@@ -28,7 +31,7 @@ public class RobotListViewColumn extends ListViewColumn {
 		}
 		return 0;
 	}
-	
+
 	public long getTotal(Job job){
 		RobotResult lastRobotResult = getLastRobotResult(job);
 		if(lastRobotResult != null){
@@ -36,7 +39,7 @@ public class RobotListViewColumn extends ListViewColumn {
 		}
 		return 0;
 	}
-	
+
 	private RobotResult getLastRobotResult(Job job){
 		Run build = job.getLastCompletedBuild();
 		if(build != null) {
@@ -47,13 +50,24 @@ public class RobotListViewColumn extends ListViewColumn {
 		}
 		return null;
 	}
-	
+
+	public boolean isRobotResultsColumnEnabled() {
+		return ((DescriptorImpl) this.getDescriptor()).isRobotResultsColumnEnabled();
+	}
+
 	@Extension
 	public static final class DescriptorImpl extends Descriptor<ListViewColumn>{
+
+		@Inject
+		private RobotConfig globalConfig;
 
 		@Override
 		public String getDisplayName() {
 			return "Robot pass/fail";
+		}
+
+		public boolean isRobotResultsColumnEnabled() {
+			return globalConfig.isRobotResultsColumnEnabled();
 		}
 	}
 }

--- a/src/main/resources/hudson/plugins/robot/RobotConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotConfig/config.jelly
@@ -1,0 +1,22 @@
+<!--
+Copyright 2008-2014 Nokia Solutions and Networks Oy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:section title="${%Robot Framework}" name="robotFramework">
+    <f:entry field="robotResultsColumnEnabled">
+      <f:checkbox name="robotResultsColumnEnabled"/>Display "Robot Results" column in the job list view
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/robot/view/RobotListViewColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/robot/view/RobotListViewColumn/column.jelly
@@ -22,9 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <j:if test="${it.isRobotResultsColumnEnabled()}">
       <td style="white-space:nowrap;">
       <j:if test="${it.getTotal(job) != 0}">
           ${it.getPass(job)} / ${it.getTotal(job)} passed <img src="${rootURL}/plugin/robot/robot.png" />
       </j:if>
       </td>
+  </j:if>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/robot/view/RobotListViewColumn/columnHeader.jelly
+++ b/src/main/resources/hudson/plugins/robot/view/RobotListViewColumn/columnHeader.jelly
@@ -22,7 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-    <th width="1" style="white-space:nowrap;">
-        Robot Results
-    </th>
+    <j:if test="${it.isRobotResultsColumnEnabled()}">
+        <th width="1" style="white-space:nowrap;">
+            Robot Results
+        </th>
+    </j:if>
 </j:jelly>


### PR DESCRIPTION
This PR implements the following issue by adding a checkbox to the Jenkins Configure page to enable/disable the "Robot Results" column:
https://issues.jenkins-ci.org/browse/JENKINS-26980

A few notes:
1. I had to increment the Jenkins version to LTS 1.447 in order to support the jenkins.model.GlobalConfiguration extension
2. The default value for the "Robot Results" column option is "enabled", so there should not be any impact/change when upgrading from a previous version
3. The RobotConfig class can be used in the future to support other types of global configuration (such as JENKINS-26245)