### PR TITLE
Revert weak to soft reference change.

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotBuildAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotBuildAction.java
@@ -33,7 +33,7 @@ import hudson.util.XStream2;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
 import java.util.Calendar;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -52,7 +52,7 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	private static final Logger logger = Logger.getLogger(RobotBuildAction.class.getName());
 	private static final XStream XSTREAM = new XStream2();
 
-	private transient SoftReference<RobotResult> resultReference;
+	private transient WeakReference<RobotResult> resultReference;
 	private transient String reportFileName;
 	private String outputPath;
 	private String logFileLink;
@@ -117,8 +117,8 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 			e.printStackTrace(listener.fatalError("Failed to save the Robot test result"));
 		}
 
-		this.resultReference = new SoftReference<RobotResult>(result);
-	}
+        this.resultReference = new WeakReference<RobotResult>(result);
+    }
 
 	private XmlFile getDataFile() {
 	   return new XmlFile(XSTREAM, new File(getOwner().getRootDir(), "robot_results.xml"));
@@ -129,17 +129,17 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	 */
 	public synchronized RobotResult getResult() {
 		RobotResult returnable;
-		if(result != null) return result;
-		if(resultReference == null) {
+		if (result != null) return result;
+		if (resultReference == null) {
 			returnable = load();
-			resultReference = new SoftReference<RobotResult>(returnable);
+			resultReference = new WeakReference<RobotResult>(returnable);
 		} else {
 			returnable = resultReference.get();
 		}
 
-		if(returnable == null) {
+		if (returnable == null) {
 			returnable = load();
-			resultReference = new SoftReference<RobotResult>(returnable);
+			resultReference = new WeakReference<RobotResult>(returnable);
 		}
 		return returnable;
 	}


### PR DESCRIPTION
In a production setting we experienced performance issues with
parallel job execution (almost 2MB robot output.xml).

RobotCaseResult and RobotSuiteResult instances would then fill up eden
space (about 500k instances after a few hours). This caused very
frequent GC pauses since garbage collection only freed up a small amount
of memory, slowing jenkins down to a crawl.
After reverting this change in a test setup GC pauses became much less
frequent since there was more eden space available.

This reverts c5084264c775f3b45b8a3e548056c234eedb86b2