### PR TITLE
Make cache based on WeakReferences optional and disabled by default

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotBuildAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotBuildAction.java
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*    http://www.apache.org/licenses/LICENSE-2.0
+*	http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,34 +15,37 @@
 */
 package hudson.plugins.robot;
 
-import com.thoughtworks.xstream.XStream;
 import hudson.FilePath;
 import hudson.XmlFile;
-import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.plugins.robot.graph.RobotGraphHelper;
+import hudson.plugins.robot.model.RobotTestObject;
 import hudson.plugins.robot.model.RobotCaseResult;
 import hudson.plugins.robot.model.RobotResult;
 import hudson.plugins.robot.model.RobotSuiteResult;
-import hudson.plugins.robot.model.RobotTestObject;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.util.ChartUtil;
 import hudson.util.Graph;
 import hudson.util.HeapSpaceStringConverter;
 import hudson.util.XStream2;
-import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.StaplerProxy;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
-import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.Calendar;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.StaplerProxy;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import com.thoughtworks.xstream.XStream;
 
 public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction> implements StaplerProxy {
 
@@ -51,12 +54,12 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 
 	private transient WeakReference<RobotResult> resultReference;
 	private transient String reportFileName;
-    private final String outputPath;
-    private final String logFileLink;
-    private final String logHtmlLink;
-    private final boolean enableCache;
-    private RobotResult result;
-    private final AbstractBuild<?, ?> build;
+	private final String outputPath;
+	private final String logFileLink;
+	private final String logHtmlLink;
+	private final boolean enableCache;
+	private RobotResult result;
+	private final AbstractBuild<?, ?> build;
 
 	static {
 		XSTREAM.alias("result",RobotResult.class);
@@ -71,17 +74,17 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	 * @param result Robot result
 	 * @param outputPath Path where the Robot report is stored relative to build root
 	 * @param logFileLink
-     * @param logHtmlLink
-     */
+	 * @param logHtmlLink
+	 */
 	public RobotBuildAction(AbstractBuild<?, ?> build, RobotResult result,
-                            String outputPath, BuildListener listener, String logFileLink, String logHtmlLink, boolean enableCache) {
-        super(build);
+							String outputPath, BuildListener listener, String logFileLink, String logHtmlLink, boolean enableCache) {
+		super(build);
 		this.build = build;
 		this.outputPath = outputPath;
 		this.logFileLink = logFileLink;
 		this.logHtmlLink = logHtmlLink;
-        this.enableCache = enableCache;
-        setResult(result, listener);
+		this.enableCache = enableCache;
+		setResult(result, listener);
 	}
 
 	/**
@@ -107,16 +110,17 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	/**
 	 * Loads new data to {@link RobotResult}.
 	 */
-	public synchronized void setResult(RobotResult result, BuildListener listener) {
-	  result.tally(this);
+	private synchronized void setResult(RobotResult result, BuildListener listener) {
+		result.tally(this);
+
 		try {
 			getDataFile().write(result);
 		} catch (IOException e) {
 			e.printStackTrace(listener.fatalError("Failed to save the Robot test result"));
 		}
 
-        cacheRobotResult(result);
-    }
+		cacheRobotResult(result);
+	}
 
 	private XmlFile getDataFile() {
 	   return new XmlFile(XSTREAM, new File(getOwner().getRootDir(), "robot_results.xml"));
@@ -128,34 +132,34 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	public synchronized RobotResult getResult() {
 		RobotResult returnable;
 
-        if (result != null) return result;
+		if (result != null) return result;
 
 		if (resultReference == null) {
 			returnable = load();
-            cacheRobotResult(returnable);
-        } else {
+			cacheRobotResult(returnable);
+		} else {
 			returnable = resultReference.get();
 		}
 
 		if (returnable == null) {
 			returnable = load();
-            cacheRobotResult(returnable);
-        }
+			cacheRobotResult(returnable);
+		}
 		return returnable;
 	}
 
-    private void cacheRobotResult(RobotResult result) {
-        if (enableCache) {
-            resultReference = new WeakReference<RobotResult>(result);
-        }
-    }
+	private void cacheRobotResult(RobotResult result) {
+		if (enableCache) {
+			resultReference = new WeakReference<RobotResult>(result);
+		}
+	}
 
 	/**
 	 * Loads a {@link RobotResult} from disk.
 	 */
 	private RobotResult load() {
-        RobotResult loadedResult;
-        try {
+		RobotResult loadedResult;
+		try {
 			loadedResult = (RobotResult)getDataFile().read();
 		} catch (IOException e) {
 			logger.log(Level.WARNING, "Couldn't load " + getDataFile(),e);
@@ -195,8 +199,8 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	 * @return test object
 	 */
 	public RobotTestObject findObjectById(String id) {
-        return getResult().findObjectById(id);
-    }
+		return getResult().findObjectById(id);
+	}
 
 	/**
 	 * Get the result object which is responsible for UI. If an old project doesn't have it provides buildaction as this.
@@ -268,7 +272,7 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 		FilePath rootDir = new FilePath(build.getRootDir());
 		if (StringUtils.isNotBlank(outputPath))
 			return new FilePath(rootDir, outputPath);
-        return rootDir;
+		return rootDir;
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *	http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,23 +22,29 @@ import hudson.Launcher;
 import hudson.matrix.MatrixAggregatable;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
-import hudson.model.*;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
 import hudson.plugins.robot.model.RobotResult;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
-import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
-import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 
 public class RobotPublisher extends Recorder implements Serializable,
 		MatrixAggregatable {
@@ -59,7 +65,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 	final private double passThreshold;
 	final private double unstableThreshold;
 	private String[] otherFiles;
-    final private boolean enableCache;
+	final private boolean enableCache;
 
 	//Default to true
 	private boolean onlyCritical = true;
@@ -69,27 +75,28 @@ public class RobotPublisher extends Recorder implements Serializable,
 	 * Create new publisher for Robot Framework results
 	 *
 	 * @param outputPath
-	 *            Path to Robot Framework's output files
+	 *			Path to Robot Framework's output files
 	 * @param outputFileName
-	 *            Name of Robot output xml
+	 *			Name of Robot output xml
 	 * @param disableArchiveOutput
-	 *            Disable Archiving output xml file to server
+	 *			Disable Archiving output xml file to server
 	 * @param reportFileName
-	 *            Name of Robot report html
+	 *			Name of Robot report html
 	 * @param logFileName
-	 *            Name of Robot log html
+	 *			Name of Robot log html
 	 * @param passThreshold
-	 *            Threshold of test pass percentage for successful builds
+	 *			Threshold of test pass percentage for successful builds
 	 * @param unstableThreshold
-	 *            Threhold of test pass percentage for unstable builds
+	 *			Threhold of test pass percentage for unstable builds
 	 * @param onlyCritical
-	 *            True if only critical tests are included in pass percentage
+	 *			True if only critical tests are included in pass percentage
 	 */
 	@DataBoundConstructor
 	public RobotPublisher(String outputPath, String outputFileName,
-                          boolean disableArchiveOutput, String reportFileName, String logFileName,
-                          double passThreshold, double unstableThreshold, boolean onlyCritical, String otherFiles, boolean enableCache) {
-        this.outputPath = outputPath;
+						  boolean disableArchiveOutput, String reportFileName, String logFileName,
+						  double passThreshold, double unstableThreshold,
+						  boolean onlyCritical, String otherFiles, boolean enableCache) {
+		this.outputPath = outputPath;
 		this.outputFileName = outputFileName;
 		this.disableArchiveOutput = disableArchiveOutput;
 		this.reportFileName = reportFileName;
@@ -97,7 +104,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 		this.unstableThreshold = unstableThreshold;
 		this.logFileName = logFileName;
 		this.onlyCritical = onlyCritical;
-        this.enableCache = enableCache;
+		this.enableCache = enableCache;
 
 		String[] filemasks = otherFiles.split(",");
 		for (int i = 0; i < filemasks.length; i++){
@@ -218,8 +225,8 @@ public class RobotPublisher extends Recorder implements Serializable,
 	 */
 	@Override
 	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
-                           BuildListener listener) throws InterruptedException, IOException {
-        if (build.getResult() != Result.ABORTED) {
+						   BuildListener listener) throws InterruptedException, IOException {
+		if (build.getResult() != Result.ABORTED) {
 			PrintStream logger = listener.getLogger();
 			logger.println(Messages.robot_publisher_started());
 			logger.println(Messages.robot_publisher_parsing());
@@ -261,8 +268,8 @@ public class RobotPublisher extends Recorder implements Serializable,
 
 			logger.println(Messages.robot_publisher_assigning());
 
-            RobotBuildAction action = new RobotBuildAction(build, result, FILE_ARCHIVE_DIR, listener, getReportFileName(), getLogFileName(), enableCache);
-            build.addAction(action);
+			RobotBuildAction action = new RobotBuildAction(build, result, FILE_ARCHIVE_DIR, listener, getReportFileName(), getLogFileName(), enableCache);
+			build.addAction(action);
 
 			logger.println(Messages.robot_publisher_done());
 			logger.println(Messages.robot_publisher_checking());
@@ -289,7 +296,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 		FilePath srcDir = new FilePath(build.getWorkspace(), inputPath);
 		FilePath destDir = new FilePath(new FilePath(build.getRootDir()),
 				FILE_ARCHIVE_DIR);
-	    srcDir.copyRecursiveTo(filemaskToCopy, destDir);
+		srcDir.copyRecursiveTo(filemaskToCopy, destDir);
 	}
 
 	/**
@@ -336,13 +343,13 @@ public class RobotPublisher extends Recorder implements Serializable,
 	 * failed before the tests it won't be changed to successful.
 	 *
 	 * @param build
-	 *            Build to be evaluated
+	 *			Build to be evaluated
 	 * @param result
-	 *            Results associated to build
+	 *			Results associated to build
 	 * @return Result of build
 	 */
-    protected Result getBuildResult(AbstractBuild<?, ?> build, RobotResult result) {
-        if (build.getResult() != Result.FAILURE) {
+	protected Result getBuildResult(AbstractBuild<?, ?> build, RobotResult result) {
+		if (build.getResult() != Result.FAILURE) {
 			double passPercentage = result.getPassPercentage(onlyCritical);
 			if (passPercentage < getUnstableThreshold()) {
 				return Result.FAILURE;

--- a/src/main/java/hudson/plugins/robot/model/RobotResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotResult.java
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*    http://www.apache.org/licenses/LICENSE-2.0
+*	http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,16 +20,23 @@ import hudson.model.AbstractBuild;
 import hudson.model.Api;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.plugins.robot.RobotBuildAction;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.*;
 
 
 /**
@@ -56,8 +63,8 @@ public class RobotResult extends RobotTestObject {
 	 * @return null if not found
 	 */
 	public RobotTestObject findObjectById(String id){
-        if (id.contains("/")) {
-            String suiteName = id.substring(0, id.indexOf("/"));
+		if (id.contains("/")) {
+			String suiteName = id.substring(0, id.indexOf("/"));
 			String childId = id.substring(id.indexOf("/")+1, id.length());
 			RobotSuiteResult suite = suites.get(suiteName);
 			return suite.findObjectById(childId);
@@ -290,11 +297,11 @@ public class RobotResult extends RobotTestObject {
 		criticalFailed = 0;
 		duration = 0;
 
-        Collection<RobotSuiteResult> newSuites = getSuites();
-        HashMap<String, RobotSuiteResult> newMap = new HashMap<String, RobotSuiteResult>(newSuites.size());
+		Collection<RobotSuiteResult> newSuites = getSuites();
+		HashMap<String, RobotSuiteResult> newMap = new HashMap<String, RobotSuiteResult>(newSuites.size());
 
-        for (RobotSuiteResult suite : newSuites) {
-            suite.tally(robotBuildAction);
+		for (RobotSuiteResult suite : newSuites) {
+			suite.tally(robotBuildAction);
 			failed += suite.getFailed();
 			passed += suite.getPassed();
 			criticalFailed += suite.getCriticalFailed();
@@ -367,8 +374,8 @@ public class RobotResult extends RobotTestObject {
 		while((build = build.getPreviousBuild()) != null) {
 			RobotBuildAction parentAction = build.getAction(getParentAction().getClass());
 			if(parentAction != null) {
-                return parentAction.getResult();
-            }
+				return parentAction.getResult();
+			}
 		}
 		return null;
 	}

--- a/src/main/java/hudson/plugins/robot/model/RobotResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotResult.java
@@ -20,23 +20,16 @@ import hudson.model.AbstractBuild;
 import hudson.model.Api;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.plugins.robot.RobotBuildAction;
-
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.*;
 
 
 /**
@@ -63,8 +56,8 @@ public class RobotResult extends RobotTestObject {
 	 * @return null if not found
 	 */
 	public RobotTestObject findObjectById(String id){
-		if(id.indexOf("/") >= 0){
-			String suiteName = id.substring(0, id.indexOf("/"));
+        if (id.contains("/")) {
+            String suiteName = id.substring(0, id.indexOf("/"));
 			String childId = id.substring(id.indexOf("/")+1, id.length());
 			RobotSuiteResult suite = suites.get(suiteName);
 			return suite.findObjectById(childId);
@@ -296,9 +289,12 @@ public class RobotResult extends RobotTestObject {
 		criticalPassed = 0;
 		criticalFailed = 0;
 		duration = 0;
-		HashMap<String, RobotSuiteResult> newMap = new HashMap<String, RobotSuiteResult>();
-		for(RobotSuiteResult suite: getSuites()){
-			suite.tally(robotBuildAction);
+
+        Collection<RobotSuiteResult> newSuites = getSuites();
+        HashMap<String, RobotSuiteResult> newMap = new HashMap<String, RobotSuiteResult>(newSuites.size());
+
+        for (RobotSuiteResult suite : newSuites) {
+            suite.tally(robotBuildAction);
 			failed += suite.getFailed();
 			passed += suite.getPassed();
 			criticalFailed += suite.getCriticalFailed();
@@ -371,9 +367,8 @@ public class RobotResult extends RobotTestObject {
 		while((build = build.getPreviousBuild()) != null) {
 			RobotBuildAction parentAction = build.getAction(getParentAction().getClass());
 			if(parentAction != null) {
-				RobotResult result = parentAction.getResult();
-				return result;
-			}
+                return parentAction.getResult();
+            }
 		}
 		return null;
 	}

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
@@ -32,7 +32,10 @@ limitations under the License.
     </f:entry>
     <f:entry title="${%advanced.disablearchiveoutputxml}" description="${%advanced.disablearchiveoutputxml.description}" field="disableArchiveOutput">
         <f:checkbox />
-  </f:entry>
+    </f:entry>
+    <f:entry title="${%advanced.enableCache}" description="${%advanced.enableCache.description}" field="enableCache">
+        <f:checkbox />
+    </f:entry>
   </f:advanced>
   <f:entry title="${%thresholds.label}" help="/plugin/robot/help-thresholds.html">
     <table width="100%">

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
@@ -12,6 +12,8 @@ advanced.loghtml=Log html name
 advanced.loghtml.description=Name of the html file containing detailed robot test log
 advanced.otherfiles=Other files to copy
 advanced.otherfiles.description=Comma separated list of robot related artifacts to be saved
+advanced.enableCache=Enable cache
+advanced.enableCache.description=Enable cache for test results
 
 thresholds.label=Thresholds for build result
 thresholds.onlycritical=Use thresholds for critical tests only

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/help-enableCache.html
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/help-enableCache.html
@@ -1,0 +1,18 @@
+<!--
+Copyright 2008-2014 Nokia Solutions and Networks Oy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div>
+    <p>Enable cache for test results (produces memory pressure)</p>
+</div>

--- a/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
@@ -15,16 +15,16 @@
 */
 package hudson.plugins.robot;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.robot.model.RobotResult;
-import junit.framework.TestCase;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import junit.framework.TestCase;
 
 
 public class RobotProjectActionTest extends TestCase {

--- a/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
@@ -15,16 +15,16 @@
 */
 package hudson.plugins.robot;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.robot.model.RobotResult;
+import junit.framework.TestCase;
 
 import java.io.File;
 import java.io.IOException;
 
-import junit.framework.TestCase;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class RobotProjectActionTest extends TestCase {
@@ -38,7 +38,7 @@ public class RobotProjectActionTest extends TestCase {
 
 	protected void tearDown() throws SecurityException {
 		if(robotFile.exists())
-				robotFile.delete();
+			robotFile.delete();
 	}
 
 	public void testShouldNotDisplayGraph() throws IOException {
@@ -56,7 +56,7 @@ public class RobotProjectActionTest extends TestCase {
 		when(build.getProject()).thenReturn(p);
 		when(build.getRootDir()).thenReturn(tmpDir);
 		RobotResult result = mock(RobotResult.class);
-		RobotBuildAction buildAction = new RobotBuildAction(build, result, "", null, null, null);
+		RobotBuildAction buildAction = new RobotBuildAction(build, result, "", null, null, null, false);
 		when(build.getAction(RobotBuildAction.class)).thenReturn(buildAction);
 		when(p.getLastBuild()).thenReturn(build);
 
@@ -72,7 +72,7 @@ public class RobotProjectActionTest extends TestCase {
 		when(buildWithAction.getProject()).thenReturn(p);
 		when(buildWithAction.getRootDir()).thenReturn(tmpDir);
 		RobotResult result = mock(RobotResult.class);
-		RobotBuildAction buildAction = new RobotBuildAction(buildWithAction, result,"", null, null, null);
+		RobotBuildAction buildAction = new RobotBuildAction(buildWithAction, result, "", null, null, null, false);
 		when(buildWithAction.getAction(RobotBuildAction.class)).thenReturn(buildAction);
 
 		when(p.getLastBuild()).thenReturn(lastBuild);

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -15,21 +15,27 @@
  */
 package hudson.plugins.robot;
 
-import com.gargoylesoftware.htmlunit.WebAssert;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlTable;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
-import hudson.model.*;
+import hudson.model.Result;
+import hudson.model.FreeStyleProject;
+import hudson.model.Hudson;
+import hudson.model.Project;
+import hudson.model.Run;
 import hudson.plugins.robot.model.RobotCaseResult;
 import hudson.plugins.robot.model.RobotResult;
-import org.junit.Assert;
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.recipes.LocalData;
 
 import java.io.File;
 import java.util.List;
 import java.util.concurrent.Future;
+
+import org.junit.Assert;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import com.gargoylesoftware.htmlunit.WebAssert;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTable;
 
 public class RobotPublisherSystemTest extends HudsonTestCase {
 

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -15,33 +15,27 @@
  */
 package hudson.plugins.robot;
 
+import com.gargoylesoftware.htmlunit.WebAssert;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTable;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
-import hudson.model.Result;
-import hudson.model.FreeStyleProject;
-import hudson.model.Hudson;
-import hudson.model.Project;
-import hudson.model.Run;
+import hudson.model.*;
 import hudson.plugins.robot.model.RobotCaseResult;
 import hudson.plugins.robot.model.RobotResult;
+import org.junit.Assert;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 import java.io.File;
 import java.util.List;
 import java.util.concurrent.Future;
 
-import org.junit.Assert;
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.recipes.LocalData;
-
-import com.gargoylesoftware.htmlunit.WebAssert;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlTable;
-
 public class RobotPublisherSystemTest extends HudsonTestCase {
 
 	public void testRoundTripConfig() throws Exception{
 		FreeStyleProject p = createFreeStyleProject();
-		RobotPublisher before = new RobotPublisher("a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png");
+		RobotPublisher before = new RobotPublisher("a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png", false);
 		p.getPublishersList().add(before);
 
 		submit(getWebClient().getPage(p, "configure")
@@ -54,7 +48,7 @@ public class RobotPublisherSystemTest extends HudsonTestCase {
 
 	public void testConfigView() throws Exception{
 		FreeStyleProject p = createFreeStyleProject();
-		RobotPublisher before = new RobotPublisher("a", "b", false,"c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png");
+		RobotPublisher before = new RobotPublisher("a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png", false);
 		p.getPublishersList().add(before);
 		HtmlPage page = getWebClient().getPage(p,"configure");
 		WebAssert.assertTextPresent(page, "Publish Robot Framework");

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -15,34 +15,39 @@
 */
 package hudson.plugins.robot;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import java.io.File;
+import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
-import hudson.model.AbstractBuild;
 import hudson.plugins.robot.model.RobotResult;
 import junit.framework.TestCase;
 
+import java.io.File;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class RobotPublisherTest extends TestCase {
+    private final boolean onlyCritical = false;
 
 	protected void setUp() throws Exception {
 		super.setUp();
 	}
 
+    private RobotPublisher getRobotPublisher(double passThreshold, double unstableThreshold) {
+        return new RobotPublisher("", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false);
+    }
+
 	public void testBlankConfigShouldReturnDefaults() {
-		RobotPublisher testable = new RobotPublisher(" "," ",false, " ", " ", 0, 0, false, "");
+        RobotPublisher testable = getRobotPublisher(0, 0);
 
 		assertEquals("output.xml", testable.getOutputFileName());
 		assertEquals("report.html", testable.getReportFileName());
 		assertEquals("log.html", testable.getLogFileName());
 	}
 
-	public void testShouldReturnSuccessWhenThresholdsExceeded() throws Exception{
-		boolean onlyCritical = false;
-
-		RobotPublisher publisher = new RobotPublisher("","",false,"","",99.9,99,onlyCritical, "");
-		RobotResult mockResult = mock(RobotResult.class);
+    public void testShouldReturnSuccessWhenThresholdsExceeded() throws Exception {
+        RobotPublisher publisher = getRobotPublisher(99.9, 99);
+        RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -52,10 +57,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldFailWhenFailedBuild() throws Exception{
-		boolean onlyCritical = false;
-
-		RobotPublisher publisher = new RobotPublisher("","",false,"","",0,0,onlyCritical, "");
-		RobotResult mockResult = mock(RobotResult.class);
+        RobotPublisher publisher = getRobotPublisher(0, 0);
+        RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.FAILURE);
@@ -65,10 +68,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldFailWhenUnstableThresholdNotExceeded(){
-		boolean onlyCritical = false;
-
-		RobotPublisher publisher = new RobotPublisher("","",false,"","",90,50,onlyCritical, "");
-		RobotResult mockResult = mock(RobotResult.class);
+        RobotPublisher publisher = getRobotPublisher(90, 50);
+        RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -78,10 +79,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldBeUnstableWhenPassThresholdNotExceeded(){
-		boolean onlyCritical = false;
-
-		RobotPublisher publisher = new RobotPublisher("","",false,"","",90,50,onlyCritical, "");
-		RobotResult mockResult = mock(RobotResult.class);
+        RobotPublisher publisher = getRobotPublisher(90, 50);
+        RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -91,10 +90,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldBeSuccessWithOnlyCritical(){
-		boolean onlyCritical = false;
-
-		RobotPublisher publisher = new RobotPublisher("","",false,"","",90,50,onlyCritical, "");
-		RobotResult mockResult = mock(RobotResult.class);
+        RobotPublisher publisher = getRobotPublisher(90, 50);
+        RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -105,14 +102,14 @@ public class RobotPublisherTest extends TestCase {
 
 	public void testShouldUnstableLowFailures() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("low_failure_output.xml", null, null);
-		RobotResult result = remoteOperation.invoke(new File(new RobotPublisherTest().getClass().getResource("low_failure_output.xml").toURI()).getParentFile(), null);
-		result.tally(null);
+        RobotResult result = remoteOperation.invoke(new File(RobotPublisherTest.class.getResource("low_failure_output.xml").toURI()).getParentFile(), null);
+        result.tally(null);
 
 		assertEquals(1, result.getOverallFailed());
 		assertEquals(2001, result.getOverallTotal());
 
-		RobotPublisher publisher = new RobotPublisher("", "", false,"", "", 100, 0, false, "");
-		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
+        RobotPublisher publisher = getRobotPublisher(100, 0);
+        AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
 

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*    http://www.apache.org/licenses/LICENSE-2.0
+*	http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,39 +15,37 @@
 */
 package hudson.plugins.robot;
 
-import hudson.model.AbstractBuild;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.File;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
+import hudson.model.AbstractBuild;
 import hudson.plugins.robot.model.RobotResult;
 import junit.framework.TestCase;
 
-import java.io.File;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class RobotPublisherTest extends TestCase {
-    private final boolean onlyCritical = false;
+	private final boolean onlyCritical = false;
 
 	protected void setUp() throws Exception {
 		super.setUp();
 	}
 
-    private RobotPublisher getRobotPublisher(double passThreshold, double unstableThreshold) {
-        return new RobotPublisher("", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false);
-    }
+	private RobotPublisher getRobotPublisher(double passThreshold, double unstableThreshold) {
+		return new RobotPublisher("", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false);
+	}
 
 	public void testBlankConfigShouldReturnDefaults() {
-        RobotPublisher testable = getRobotPublisher(0, 0);
+		RobotPublisher testable = getRobotPublisher(0, 0);
 
 		assertEquals("output.xml", testable.getOutputFileName());
 		assertEquals("report.html", testable.getReportFileName());
 		assertEquals("log.html", testable.getLogFileName());
 	}
 
-    public void testShouldReturnSuccessWhenThresholdsExceeded() throws Exception {
-        RobotPublisher publisher = getRobotPublisher(99.9, 99);
-        RobotResult mockResult = mock(RobotResult.class);
+	public void testShouldReturnSuccessWhenThresholdsExceeded() throws Exception {
+		RobotPublisher publisher = getRobotPublisher(99.9, 99);
+		RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -57,8 +55,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldFailWhenFailedBuild() throws Exception{
-        RobotPublisher publisher = getRobotPublisher(0, 0);
-        RobotResult mockResult = mock(RobotResult.class);
+		RobotPublisher publisher = getRobotPublisher(0, 0);
+		RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.FAILURE);
@@ -68,8 +66,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldFailWhenUnstableThresholdNotExceeded(){
-        RobotPublisher publisher = getRobotPublisher(90, 50);
-        RobotResult mockResult = mock(RobotResult.class);
+		RobotPublisher publisher = getRobotPublisher(90, 50);
+		RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -79,8 +77,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldBeUnstableWhenPassThresholdNotExceeded(){
-        RobotPublisher publisher = getRobotPublisher(90, 50);
-        RobotResult mockResult = mock(RobotResult.class);
+		RobotPublisher publisher = getRobotPublisher(90, 50);
+		RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -90,8 +88,8 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldBeSuccessWithOnlyCritical(){
-        RobotPublisher publisher = getRobotPublisher(90, 50);
-        RobotResult mockResult = mock(RobotResult.class);
+		RobotPublisher publisher = getRobotPublisher(90, 50);
+		RobotResult mockResult = mock(RobotResult.class);
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
@@ -102,14 +100,14 @@ public class RobotPublisherTest extends TestCase {
 
 	public void testShouldUnstableLowFailures() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("low_failure_output.xml", null, null);
-        RobotResult result = remoteOperation.invoke(new File(RobotPublisherTest.class.getResource("low_failure_output.xml").toURI()).getParentFile(), null);
-        result.tally(null);
+		RobotResult result = remoteOperation.invoke(new File(RobotPublisherTest.class.getResource("low_failure_output.xml").toURI()).getParentFile(), null);
+		result.tally(null);
 
 		assertEquals(1, result.getOverallFailed());
 		assertEquals(2001, result.getOverallTotal());
 
-        RobotPublisher publisher = getRobotPublisher(100, 0);
-        AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
+		RobotPublisher publisher = getRobotPublisher(100, 0);
+		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
 

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -16,12 +16,11 @@
 package hudson.plugins.robot.model;
 
 import hudson.plugins.robot.RobotParser;
+import junit.framework.TestCase;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
 import java.util.List;
-
-import junit.framework.TestCase;
-import org.apache.commons.lang.StringUtils;
 
 
 public class RobotResultTest extends TestCase {
@@ -32,7 +31,7 @@ public class RobotResultTest extends TestCase {
 		super.setUp();
 
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", null, null);
-		result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 	}
 
@@ -83,7 +82,7 @@ public class RobotResultTest extends TestCase {
 	public void testShouldParseNewCriticalCases() throws Exception{
 
         RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
-		result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("new_critical_output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
 		assertEquals(14, result.getCriticalTotal());
@@ -103,7 +102,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldParseFailedNewCriticalCases() throws Exception{
 		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
-			result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("new_critical_output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
 		assertEquals(7, result.getCriticalFailed());
@@ -111,7 +110,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldAcceptNoLogAndReport() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
-		result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("new_critical_output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
 		assertFalse(result.getAllFailedCases().get(0).getHasLog());
@@ -120,7 +119,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldGetLogWhenAvailable() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", "log.html", "report.html");
-		result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("new_critical_output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
 		assertTrue(result.getAllFailedCases().get(0).getHasLog());
@@ -128,7 +127,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldGetLogAndReportInSuites() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", "log.html", "report.html");
-		result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
 		RobotSuiteResult suite = result.getSuite("Othercases & Testcases");
@@ -138,7 +137,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testIdShouldBeEmptyWhenNotAvailable() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", "log.html", null);
-		result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("new_critical_output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
 		assertEquals("", result.getAllFailedCases().get(0).getId());
@@ -146,7 +145,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldGetIdWhenAvailable() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("teardown_fail.xml", "log.html", null);
-		result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("teardown_fail.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("teardown_fail.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 		RobotSuiteResult suite = result.getSuite("Fail");
 		RobotSuiteResult subSuite = suite.getSuite("Suite");
@@ -157,7 +156,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldParseCriticalityFromStatusInsteadOfTest() throws Exception{
 		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
-			result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("new_critical_output.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
 		RobotSuiteResult suite = result.getSuite("Othercases & Testcases");
@@ -204,7 +203,7 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldParseSplittedOutput() throws Exception {
 		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("testfile.xml", null, null);
-			result = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("testfile.xml").toURI()).getParentFile(), null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("testfile.xml").toURI()).getParentFile(), null);
 
 		RobotSuiteResult suite = result.getSuite("nestedSuites");
 		RobotSuiteResult splittedSuite = suite.getSuite("subSuite");
@@ -214,21 +213,21 @@ public class RobotResultTest extends TestCase {
 
 	public void testShouldParseSuiteTeardownFailures() throws Exception {
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("teardown_fail.xml", null, null);
-		RobotResult res = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("teardown_fail.xml").toURI()).getParentFile(), null);
+		RobotResult res = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("teardown_fail.xml").toURI()).getParentFile(), null);
 		List<RobotCaseResult> failers = res.getAllFailedCases();
 		assertEquals(3, failers.size());
 	}
 
 	public void testShouldHandleNameCollisions() throws Exception {
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("collisions.xml", null, null);
-		RobotResult res = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("collisions.xml").toURI()).getParentFile(), null);
+		RobotResult res = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("collisions.xml").toURI()).getParentFile(), null);
 		List<RobotCaseResult> failers = res.getAllFailedCases();
 		assertEquals(3, failers.size());
 	}
 
 	public void testShouldParseWholeSuiteDuration() throws Exception {
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("suite-setup-and-teardown.xml", null, null);
-		RobotResult res = remoteOperation.invoke(new File(new RobotSuiteResultTest().getClass().getResource("suite-setup-and-teardown.xml").toURI()).getParentFile(), null);
+		RobotResult res = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("suite-setup-and-teardown.xml").toURI()).getParentFile(), null);
 		res.tally(null);
 		assertEquals(10141, res.getDuration());
 	}

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*    http://www.apache.org/licenses/LICENSE-2.0
+*	http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,11 +16,12 @@
 package hudson.plugins.robot.model;
 
 import hudson.plugins.robot.RobotParser;
-import junit.framework.TestCase;
-import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
 import java.util.List;
+
+import junit.framework.TestCase;
+import org.apache.commons.lang.StringUtils;
 
 
 public class RobotResultTest extends TestCase {
@@ -81,7 +82,7 @@ public class RobotResultTest extends TestCase {
 	}
 	public void testShouldParseNewCriticalCases() throws Exception{
 
-        RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 


### PR DESCRIPTION
It helped in highload Jenkins installation to solve performance problem. It looks like CMS GC has some problems with huge number of weak referenced object (~50k) and FullGC pause becomes too long (up to 10-15 seconds). I failed to find any prove for it - only my personal experience and my ex-colleague's experience.
http://stackoverflow.com/questions/33678319/when-does-gc-remove-objects-that-have-only-weak-references (my question)
http://stackoverflow.com/questions/1250502/cost-of-using-weak-references-in-java (first answer)