### PR TITLE
handle empty or invalid maxBuildToShow parameter

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotBuildAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotBuildAction.java
@@ -255,12 +255,16 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 		if (req.checkIfModified(t, rsp))
 			return;
 
+		String maxBuildsReq = req.getParameter("maxBuildsToShow");
+		if (maxBuildsReq == null || maxBuildsReq.isEmpty())
+			maxBuildsReq = "0"; // show all builds by default
+
 		Graph g = RobotGraphHelper.createTestResultsGraphForTestObject(getResult(),
 				Boolean.valueOf(req.getParameter("zoomSignificant")), false,
 				Boolean.valueOf(req.getParameter("hd")),
 				Boolean.valueOf(req.getParameter("failedOnly")),
 				Boolean.valueOf(req.getParameter("criticalOnly")),
-				Integer.valueOf(req.getParameter("maxBuildsToShow")));
+				Integer.valueOf(maxBuildsReq));
 		g.doPng(req, rsp);
 	}
 


### PR DESCRIPTION
I am having trouble showing the trend of my job by its URI http://<jenkins>/<job>/test/trend

part of the received StackTrace:
Caused by: java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:454)
	at java.lang.Integer.valueOf(Integer.java:582)
	at hudson.plugins.robot.RobotBuildAction.doGraph(RobotBuildAction.java:248)
	at hudson.tasks.test.TestResultProjectAction.doTrend(TestResultProjectAction.java:111)
	at sun.reflect.GeneratedMethodAccessor398.invoke(Unknown Source)


by merging my commit, the REST API of the robot-plugin would be more stable and backwards compatible (newly introduced parameter maxBuildToShow is optional)

This only needs to be handled for maxBuildToShow, because:
Integer.valueOf(null) does throw a NumberFormatException
Boolean.valueOf(null) does not throw
