### PR TITLE
Add tag include and exclude options

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -63,6 +63,8 @@ public class RobotPublisher extends Recorder implements Serializable,
 	final private double unstableThreshold;
 	private String[] otherFiles;
 	final private boolean enableCache;
+	private String[] includeTags;
+	private String[] excludeTags;
 
 	//Default to true
 	private boolean onlyCritical = true;
@@ -91,12 +93,17 @@ public class RobotPublisher extends Recorder implements Serializable,
 	 * 			Other files to be saved
 	 * @param enableCache
 	 * 			True if caching is used
+	 * @param includeTags
+	 * 			Include only tests with these tags
+	 * @param excludeTags
+	 * 			Exclude tests with these tags
 	 */
 	@DataBoundConstructor
 	public RobotPublisher(String outputPath, String outputFileName,
 						  boolean disableArchiveOutput, String reportFileName, String logFileName,
 						  double passThreshold, double unstableThreshold,
-						  boolean onlyCritical, String otherFiles, boolean enableCache) {
+						  boolean onlyCritical, String otherFiles, boolean enableCache,
+						  String includeTags, String excludeTags) {
 		this.outputPath = outputPath;
 		this.outputFileName = outputFileName;
 		this.disableArchiveOutput = disableArchiveOutput;
@@ -113,6 +120,14 @@ public class RobotPublisher extends Recorder implements Serializable,
 				filemasks[i] = StringUtils.strip(filemasks[i]);
 			}
 			this.otherFiles = filemasks;
+		}
+
+		if (includeTags != null) {
+			this.includeTags = includeTags.split("[, ]+");
+		}
+
+		if (excludeTags != null) {
+			this.excludeTags = excludeTags.split("[, ]+");
 		}
 	}
 
@@ -205,6 +220,22 @@ public class RobotPublisher extends Recorder implements Serializable,
 	}
 
 	/**
+	 * Gets the comma separated list of tags to include
+	 * @return List of tags as string
+	 */
+	public String getIncludeTags() {
+		return StringUtils.join(includeTags, ",");
+	}
+
+	/**
+	 * Gets the comma separated list of tags to exclude
+	 * @return List of tags as string
+	 */
+	public String getExcludeTags() {
+		return StringUtils.join(excludeTags, ",");
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	@Override
@@ -218,7 +249,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 	protected RobotResult parse(String expandedTestResults, String outputPath, Run<?,?> build, FilePath workspace,
 			Launcher launcher, TaskListener listener) throws IOException,
 			InterruptedException {
-		return new RobotParser().parse(expandedTestResults, outputPath, build, workspace, getLogFileName(), getReportFileName());
+		return new RobotParser().parse(expandedTestResults, outputPath, build, workspace, getLogFileName(), getReportFileName(), includeTags, excludeTags);
 	}
 
 	/**
@@ -229,6 +260,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 		if (build.getResult() != Result.ABORTED) {
 			PrintStream logger = listener.getLogger();
 			logger.println(Messages.robot_publisher_started());
+			logger.println(String.format("Using '%s', '%s'", StringUtils.join(includeTags, ","), StringUtils.join(excludeTags, ",")));
 			logger.println(Messages.robot_publisher_parsing());
 			RobotResult result;
 

--- a/src/main/java/hudson/plugins/robot/RobotStep.java
+++ b/src/main/java/hudson/plugins/robot/RobotStep.java
@@ -38,6 +38,8 @@ public class RobotStep extends Step {
 	private @CheckForNull String[] otherFiles;
 	private boolean enableCache = true;
 	private boolean onlyCritical = true;
+	private @CheckForNull String[] includeTags;
+	private @CheckForNull String[] excludeTags;
 
 	
 	
@@ -89,7 +91,15 @@ public class RobotStep extends Step {
 	public boolean getOnlyCritical() {
 		return this.onlyCritical;
 	}
-	
+
+	public String getIncludeTags() {
+		return StringUtils.join(includeTags, ",");
+	}
+
+	public String getExcludeTags() {
+		return StringUtils.join(excludeTags, ",");
+	}	
+
 	@DataBoundSetter
 	public void setReportFileName(String reportFileName) {
 		this.reportFileName = Util.fixEmpty(reportFileName);
@@ -139,6 +149,22 @@ public class RobotStep extends Step {
 				filemasks[i] = StringUtils.strip(filemasks[i]);
 			}
 			this.otherFiles = filemasks;
+		}
+	}
+
+	@DataBoundSetter
+	public void setIncludeTags(String includeTags) {
+		includeTags = Util.fixEmpty(includeTags);
+		if (includeTags != null) {
+			this.includeTags = includeTags.split("[, ]+");
+		}
+	}
+
+	@DataBoundSetter
+	public void setExcludeTags(String excludeTags) {
+		excludeTags = Util.fixEmpty(excludeTags);
+		if (excludeTags != null) {
+			this.excludeTags = excludeTags.split("[, ]+");
 		}
 	}
 

--- a/src/main/java/hudson/plugins/robot/RobotStepExecution.java
+++ b/src/main/java/hudson/plugins/robot/RobotStepExecution.java
@@ -28,7 +28,11 @@ public class RobotStepExecution extends SynchronousNonBlockingStepExecution<Void
     @Override protected Void run() throws Exception {
     	FilePath workspace = getContext().get(FilePath.class);
         workspace.mkdirs();
-    	RobotPublisher rp = new RobotPublisher(step.getOutputPath(), step.getOutputFileName(), step.getDisableArchiveOutput(), step.getReportFileName(), step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), step.getOnlyCritical(), step.getOtherFiles(), step.getEnableCache());
+        RobotPublisher rp = new RobotPublisher(step.getOutputPath(), step.getOutputFileName(), 
+                                               step.getDisableArchiveOutput(), step.getReportFileName(), 
+                                               step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), 
+                                               step.getOnlyCritical(), step.getOtherFiles(), step.getEnableCache(), 
+                                               step.getIncludeTags(), step.getExcludeTags());
     	rp.perform(getContext().get(Run.class), workspace, getContext().get(Launcher.class), getContext().get(TaskListener.class));
     	return null;
     }

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
@@ -29,6 +29,12 @@ limitations under the License.
     <f:entry title="${%advanced.loghtml}" description="${%advanced.loghtml.description}" field="logFileName">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%advanced.includeTags}" description="${%advanced.includeTags.description}" field="includeTags">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%advanced.excludeTags}" description="${%advanced.excludeTags.description}" field="excludeTags">
+        <f:textbox />
+    </f:entry>
     <f:entry title="${%advanced.otherfiles}" description="${%advanced.otherfiles.description}" field="otherFiles">
         <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
@@ -14,6 +14,9 @@ advanced.otherfiles=Other files to copy
 advanced.otherfiles.description=Comma separated list of robot related artifacts to be saved
 advanced.enableCache=Enable cache
 advanced.enableCache.description=Enable cache for test results
-
+advanced.includeTags=Include Tags
+advanced.includeTags.description=Comma separated list of tags to include
+advanced.excludeTags=Exclude Tags
+advanced.excludeTags.description=Comma separated list of tags to exclude
 thresholds.label=Thresholds for build result
 thresholds.onlycritical=Use thresholds for critical tests only

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/help-excludeTags.html
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/help-excludeTags.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Tests that match these tags are completely excluded.</p>
+</div>

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/help-includeTags.html
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/help-includeTags.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Only include tests with these tags.</p>
+    <p>If empty all tests are included.</p>
+</div>

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
@@ -29,6 +29,12 @@ limitations under the License.
     <f:entry title="${%advanced.loghtml}" description="${%advanced.loghtml.description}" field="logFileName">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%advanced.includeTags}" description="${%advanced.includeTags.description}" field="includeTags">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%advanced.excludeTags}" description="${%advanced.excludeTags.description}" field="excludeTags">
+        <f:textbox />
+    </f:entry>
     <f:entry title="${%advanced.otherfiles}" description="${%advanced.otherfiles.description}" field="otherFiles">
         <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
@@ -14,6 +14,9 @@ advanced.otherfiles=Other files to copy
 advanced.otherfiles.description=Comma separated list of robot related artifacts to be saved
 advanced.enableCache=Enable cache
 advanced.enableCache.description=Enable cache for test results
-
+advanced.includeTags=Include Tags
+advanced.includeTags.description=Comma separated list of tags to include
+advanced.excludeTags=Exclude Tags
+advanced.excludeTags.description=Comma separated list of tags to exclude
 thresholds.label=Thresholds for build result
 thresholds.onlycritical=Use thresholds for critical tests only

--- a/src/main/resources/hudson/plugins/robot/RobotStep/help-excludeTags.html
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/help-excludeTags.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Tests that match these tags are completely excluded.</p>
+</div>

--- a/src/main/resources/hudson/plugins/robot/RobotStep/help-includeTags.html
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/help-includeTags.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Only include tests with these tags.</p>
+    <p>If empty all tests are included.</p>
+</div>

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -57,12 +57,12 @@ public class RobotPublisherSystemTest {
 	public void testRoundTripConfig() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testRoundTripConfig");
 		RobotPublisher before = new RobotPublisher("a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
-				false);
+				false, "include,include2", "exclude,exclude2");
 		p.getPublishersList().add(before);
 		j.configRoundtrip(p);
 		RobotPublisher after = p.getPublishersList().get(RobotPublisher.class);
 		assertThat(
-				"outputPath,outputFileName,reportFileName,logFileName,passThreshold,unstableThreshold,onlyCritical,otherFiles",
+				"outputPath,outputFileName,reportFileName,logFileName,passThreshold,unstableThreshold,onlyCritical,otherFiles,includeTags,excludeTags",
 				before, samePropertyValuesAs(after));
 	}
 
@@ -70,7 +70,7 @@ public class RobotPublisherSystemTest {
 	public void testConfigView() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testConfigView");
 		RobotPublisher before = new RobotPublisher("a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
-				false);
+				false, "include,include2", "exclude,exclude2");
 		p.getPublishersList().add(before);
 		HtmlPage page = j.createWebClient().getPage(p, "configure");
 		WebAssert.assertTextPresent(page, "Publish Robot Framework");
@@ -82,6 +82,10 @@ public class RobotPublisherSystemTest {
 		WebAssert.assertInputContainsValue(page, "_.reportFileName", "c");
 		WebAssert.assertInputPresent(page, "_.logFileName");
 		WebAssert.assertInputContainsValue(page, "_.logFileName", "d");
+		WebAssert.assertInputPresent(page, "_.includeTags");
+		WebAssert.assertInputContainsValue(page, "_.includeTags", "include,include2");
+		WebAssert.assertInputPresent(page, "_.excludeTags");
+		WebAssert.assertInputContainsValue(page, "_.excludeTags", "exclude,exclude2");
 		WebAssert.assertInputPresent(page, "_.unstableThreshold");
 		WebAssert.assertInputContainsValue(page, "_.unstableThreshold", "27.0");
 		WebAssert.assertInputPresent(page, "_.passThreshold");

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -35,7 +35,7 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	private RobotPublisher getRobotPublisher(double passThreshold, double unstableThreshold) {
-		return new RobotPublisher("", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false);
+		return new RobotPublisher("", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false, null, null);
 	}
 
 	public void testBlankConfigShouldReturnDefaults() {
@@ -102,7 +102,7 @@ public class RobotPublisherTest extends TestCase {
 	}
 
 	public void testShouldUnstableLowFailures() throws Exception{
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("low_failure_output.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("low_failure_output.xml", null, null, null, null);
 		RobotResult result = remoteOperation.invoke(new File(RobotPublisherTest.class.getResource("low_failure_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -118,7 +118,7 @@ public class RobotPublisherTest extends TestCase {
 	}
 	
 	public void testShouldHandleDurationWithoutTimes() throws Exception {
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("rebot_output.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("rebot_output.xml", null, null, null, null);
 		RobotResult result = remoteOperation.invoke(new File(RobotPublisherTest.class.getResource("rebot_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 

--- a/src/test/java/hudson/plugins/robot/graph/RobotGraphHelperTest.java
+++ b/src/test/java/hudson/plugins/robot/graph/RobotGraphHelperTest.java
@@ -36,7 +36,7 @@ public class RobotGraphHelperTest extends TestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", null, null, null, null);
 		RobotResult result = remoteOperation.invoke(new File(new RobotGraphHelperTest().getClass().getResource("output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -36,7 +36,7 @@ public class RobotResultTest {
 
 	@Before
 	public void setUp() throws Exception {
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", null, null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 	}
@@ -112,7 +112,7 @@ public class RobotResultTest {
 	@Test
 	public void testShouldParseNewCriticalCases() throws Exception{
 
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -136,7 +136,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldParseFailedNewCriticalCases() throws Exception{
-		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
+		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -145,7 +145,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldAcceptNoLogAndReport() throws Exception{
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -155,7 +155,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldGetLogWhenAvailable() throws Exception{
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", "log.html", "report.html");
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", "log.html", "report.html", null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -164,7 +164,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldGetLogAndReportInSuites() throws Exception{
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", "log.html", "report.html");
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("output.xml", "log.html", "report.html", null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -175,7 +175,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testIdShouldBeEmptyWhenNotAvailable() throws Exception{
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", "log.html", null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", "log.html", null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -184,7 +184,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldGetIdWhenAvailable() throws Exception{
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("teardown_fail.xml", "log.html", null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("teardown_fail.xml", "log.html", null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("teardown_fail.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 		RobotSuiteResult suite = result.getSuite("Fail");
@@ -196,7 +196,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldParseCriticalityFromStatusInsteadOfTest() throws Exception{
-		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
+		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
 		result.tally(null);
 
@@ -251,7 +251,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldParseSplittedOutput() throws Exception {
-		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("testfile.xml", null, null);
+		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("testfile.xml", null, null, null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("testfile.xml").toURI()).getParentFile(), null);
 
 		RobotSuiteResult suite = result.getSuite("nestedSuites");
@@ -262,7 +262,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldParseSuiteTeardownFailures() throws Exception {
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("teardown_fail.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("teardown_fail.xml", null, null, null, null);
 		RobotResult res = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("teardown_fail.xml").toURI()).getParentFile(), null);
 		List<RobotCaseResult> failers = res.getAllFailedCases();
 		assertEquals(3, failers.size());
@@ -270,7 +270,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldHandleNameCollisions() throws Exception {
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("collisions.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("collisions.xml", null, null, null, null);
 		RobotResult res = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("collisions.xml").toURI()).getParentFile(), null);
 		List<RobotCaseResult> failers = res.getAllFailedCases();
 		assertEquals(4, failers.size());
@@ -278,7 +278,7 @@ public class RobotResultTest {
 
 	@Test
 	public void testShouldParseWholeSuiteDuration() throws Exception {
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("suite-setup-and-teardown.xml", null, null);
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("suite-setup-and-teardown.xml", null, null, null, null);
 		RobotResult res = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("suite-setup-and-teardown.xml").toURI()).getParentFile(), null);
 		res.tally(null);
 		assertEquals(10141, res.getDuration());


### PR DESCRIPTION
This works the same way as --include and --exclude of the
robot command line utility.
It can be used for example for filtering out skipped tests,
that were marked with a specific tag

Signed-off-by: Joerg Vehlow <joerg.vehlow@aox-tech.de>