### PR TITLE
RobotParser: handle empty arguments tags

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -294,16 +294,18 @@ public class RobotParser {
 						String kw = reader.getAttributeValue(null, "name");
 						stackTrace.append(getSpacesPerNestedLevel(nestedCount) + kw);
 						xmlTag = ignoreUntilStarts(reader, "kw", "arguments", "status");
-						//get arguments of current keyword
+						//get arguments of current keyword if any
 						if (xmlTag == "arguments") {
-							xmlTag = ignoreUntilStarts(reader, "arg");
-							do {
-								reader.next(); //skip arg start
-								stackTrace.append("    " + reader.getText());
-								reader.next(); //skip text
-								reader.next(); //skip arg end
-								reader.next(); //skip WS
-							} while (reader.isStartElement() && reader.getLocalName() == "arg");
+							while (reader.hasNext() && !(reader.isEndElement() && reader.getLocalName() == "arguments")) {
+								reader.next();
+								if (reader.isStartElement() && reader.getLocalName() == "arg") {
+									reader.next(); //skip arg start
+									stackTrace.append("    " + reader.getText());
+									reader.next(); //skip text
+									reader.next(); //skip arg end
+									reader.next(); //skip WS
+								}
+							}
 							xmlTag = ignoreUntilStarts(reader, "kw", "status");
 						}
 						stackTrace.append("\n");

--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -303,7 +303,6 @@ public class RobotParser {
 									stackTrace.append("    " + reader.getText());
 									reader.next(); //skip text
 									reader.next(); //skip arg end
-									reader.next(); //skip WS
 								}
 							}
 							xmlTag = ignoreUntilStarts(reader, "kw", "status");


### PR DESCRIPTION
Old versions of RF, e.g. Robot 2.8.5 (Python 2.7.9 on linux2), can produce an output file with empty "arguments" tags, i.e. no arg child. Parsing such file would break as ignoreUntilStarts would throw an exception due to not finding the arg starting tag.

This fix replace usage of ignoreUntilStarts to a more manual parsing to handle this case.