### PR TITLE
Fix robot-plugin installation when Blue Ocean is not installed

### DIFF
--- a/src/main/java/hudson/plugins/robot/blueocean/BlueRobotTestResult.java
+++ b/src/main/java/hudson/plugins/robot/blueocean/BlueRobotTestResult.java
@@ -75,7 +75,7 @@ public class BlueRobotTestResult extends BlueTestResult {
 		return false;
 	}
 
-	@Extension
+	@Extension(optional = true)
 	public static class FactoryImpl extends BlueTestResultFactory {
 		@Override
 		public Result getBlueTestResults(Run<?,?> run, final Reachable parent) {


### PR DESCRIPTION
Fix issue that Blue Ocean was incorrectly interpreted as a mandatory dependency