### PR TITLE
Fix token macros for pipelines

### DIFF
--- a/src/main/java/hudson/plugins/robot/tokens/RobotFailTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotFailTokenMacro.java
@@ -1,7 +1,9 @@
 package hudson.plugins.robot.tokens;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.robot.RobotBuildAction;
 import hudson.plugins.robot.model.RobotResult;
@@ -20,6 +22,11 @@ public class RobotFailTokenMacro extends DataBoundTokenMacro {
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
 			InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
@@ -29,7 +36,6 @@ public class RobotFailTokenMacro extends DataBoundTokenMacro {
 				return Long.toString(result.getOverallFailed());
 		}
 		return "";
-		
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/robot/tokens/RobotFailedCasesTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotFailedCasesTokenMacro.java
@@ -1,6 +1,8 @@
 package hudson.plugins.robot.tokens;
 
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.plugins.robot.RobotBuildAction;
@@ -19,17 +21,22 @@ public class RobotFailedCasesTokenMacro extends DataBoundTokenMacro {
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
 			InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if (action!=null){
 			RobotResult result = action.getResult();
 			StringBuilder builder = new StringBuilder();
-			
+
 			String newline = "";
 			for (RobotCaseResult failedCase : result.getAllFailedCases()){
 				builder.append(newline).append(failedCase.getRelativePackageName(result));
 				newline = "\n";
 			}
-			
+
 			return builder.toString();
 		}
 		return "";

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacro.java
@@ -1,6 +1,8 @@
 package hudson.plugins.robot.tokens;
 
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.plugins.robot.RobotBuildAction;
@@ -24,13 +26,18 @@ public class RobotPassPercentageTokenMacro extends DataBoundTokenMacro {
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
 			InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName)
+			throws MacroEvaluationException {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
-		
+
 		if (action!=null){
 			RobotResult result = action.getResult();
 			return String.valueOf(result.getPassPercentage(onlyCritical));
 		}
-		
 		return "";
 	}
 

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
@@ -1,6 +1,8 @@
 package hudson.plugins.robot.tokens;
 
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.plugins.robot.RobotBuildAction;
@@ -21,6 +23,12 @@ public class RobotPassRatioTokenMacro extends DataBoundTokenMacro {
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
 			InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName)
+			throws MacroEvaluationException {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
@@ -30,7 +38,6 @@ public class RobotPassRatioTokenMacro extends DataBoundTokenMacro {
 				return result.getOverallPassed() + " / " + result.getOverallTotal();
 		}
 		return "";
-		
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassTokenMacro.java
@@ -1,7 +1,9 @@
 package hudson.plugins.robot.tokens;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.robot.RobotBuildAction;
 import hudson.plugins.robot.model.RobotResult;
@@ -20,6 +22,12 @@ public class RobotPassTokenMacro extends DataBoundTokenMacro {
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
 			InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName)
+			throws MacroEvaluationException {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
@@ -29,7 +37,6 @@ public class RobotPassTokenMacro extends DataBoundTokenMacro {
 				return Long.toString(result.getOverallPassed());
 		}
 		return "";
-		
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/robot/tokens/RobotReportLinkTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotReportLinkTokenMacro.java
@@ -1,6 +1,8 @@
 package hudson.plugins.robot.tokens;
 
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.model.Hudson;
@@ -19,9 +21,15 @@ public class RobotReportLinkTokenMacro extends DataBoundTokenMacro {
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
 			InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName)
+			throws MacroEvaluationException {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if (action!=null){
-			String rootURL = (Jenkins.getInstanceOrNull() != null) ? Jenkins.getInstance().getRootUrl() : "";
+			String rootURL = (Jenkins.getInstanceOrNull() != null) ? Jenkins.get().getRootUrl() : "";
 			if (action.getLogFileLink() == null)
 				return rootURL + context.getUrl()+ action.getUrlName() + "/report/";
 			else

--- a/src/main/java/hudson/plugins/robot/tokens/RobotTotalTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotTotalTokenMacro.java
@@ -1,7 +1,9 @@
 package hudson.plugins.robot.tokens;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.robot.RobotBuildAction;
 import hudson.plugins.robot.model.RobotResult;
@@ -20,6 +22,12 @@ public class RobotTotalTokenMacro extends DataBoundTokenMacro {
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
 			InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName)
+			throws MacroEvaluationException {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
@@ -29,7 +37,6 @@ public class RobotTotalTokenMacro extends DataBoundTokenMacro {
 				return Long.toString(result.getOverallTotal());
 		}
 		return "";
-		
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes issue when token macros didn't expand correctly when running email-ext plugin in pipelines.