### PR TITLE
[JENKINS-36954] Make Matrix-project a mandatory dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>matrix-project</artifactId>
 			<version>${matrix-project.version}</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Having Matrix-project as an optional dependency enables to have a Jenkins where it's not installed. However `RobotPublisher.java` implements a class from Matrix-project plugin making it a mandatory dependency.