### PR TITLE
[JENKINS-63900] Allow overwriting default x axis label per job.

### DIFF
--- a/src/main/java/hudson/plugins/robot/AggregatedRobotAction.java
+++ b/src/main/java/hudson/plugins/robot/AggregatedRobotAction.java
@@ -23,6 +23,7 @@ import hudson.plugins.robot.graph.RobotGraphHelper;
 import hudson.plugins.robot.model.RobotResult;
 import hudson.util.ChartUtil;
 import hudson.util.Graph;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -92,8 +93,8 @@ public class AggregatedRobotAction implements Action {
 
 		if (req.checkIfModified(t, rsp))
 			return;
-
-		String labelFormat = RobotConfig.getInstance().getXAxisLabelFormat();
+		String label = getChildBuildAction(build).getxAxisLabel();
+		String labelFormat = StringUtils.isBlank(label) ? RobotConfig.getInstance().getXAxisLabelFormat() : label;
 		Graph g = RobotGraphHelper.createTestResultsGraphForTestObject(getResult(),
 				Boolean.valueOf(req.getParameter("zoomSignificant")),
 				false, Boolean.valueOf(req.getParameter("hd")),

--- a/src/main/java/hudson/plugins/robot/RobotBuildAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotBuildAction.java
@@ -63,6 +63,7 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	private final boolean enableCache;
 	private Run<?, ?> build;
 	private RobotResult result;
+	private String xAxisLabel;
 
 	static {
 		XSTREAM.alias("result",RobotResult.class);
@@ -82,7 +83,7 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	 * @param enableCache Whether we want to enable caching or not
 	 */
 	public RobotBuildAction(Run<?, ?> build, RobotResult result,
-			String outputPath, TaskListener listener, String logFileLink, String logHtmlLink, boolean enableCache) {
+			String outputPath, TaskListener listener, String logFileLink, String logHtmlLink, boolean enableCache, String xAxisLabel) {
 		super();
 		super.onAttached(build);
 		this.build = build;
@@ -90,6 +91,7 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 		this.logFileLink = logFileLink;
 		this.logHtmlLink = logHtmlLink;
 		this.enableCache = enableCache;
+		this.xAxisLabel = xAxisLabel;
 		setResult(result, listener);
 	}
 

--- a/src/main/java/hudson/plugins/robot/RobotBuildAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotBuildAction.java
@@ -221,6 +221,10 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 		return getResult();
 	}
 
+	public String getxAxisLabel() {
+		return xAxisLabel;
+	}
+
 	/**
 	 * Serves Robot html report via robot url. Shows not found page if file is missing.
 	 * @param req StaplerRequest
@@ -270,7 +274,7 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 		if (maxBuildsReq == null || maxBuildsReq.isEmpty())
 			maxBuildsReq = "0"; // show all builds by default
 
-		String labelFormat = RobotConfig.getInstance().getXAxisLabelFormat();
+		String labelFormat = StringUtils.isBlank(xAxisLabel) ? RobotConfig.getInstance().getXAxisLabelFormat() : xAxisLabel;
 		Graph g = RobotGraphHelper.createTestResultsGraphForTestObject(getResult(),
 				Boolean.valueOf(req.getParameter("zoomSignificant")), false,
 				Boolean.valueOf(req.getParameter("hd")),

--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -270,7 +270,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 				logger.println(Messages.robot_publisher_done());
 				logger.println(Messages.robot_publisher_assigning());
 
-				RobotBuildAction action = new RobotBuildAction(build, result, FILE_ARCHIVE_DIR, listener, expandedReportFileName, expandedLogFileName, enableCache);
+				RobotBuildAction action = new RobotBuildAction(build, result, FILE_ARCHIVE_DIR, listener, expandedReportFileName, expandedLogFileName, enableCache, overwriteXAxisLabel);
 				build.addAction(action);
 
 				// set RobotProjectAction as project action for Blue Ocean

--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -62,6 +62,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 	final private double passThreshold;
 	final private double unstableThreshold;
 	private String[] otherFiles;
+	final private String overwriteXAxisLabel;
 	final private boolean enableCache;
 
 	//Default to true
@@ -95,7 +96,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 	public RobotPublisher(String outputPath, String outputFileName,
 						boolean disableArchiveOutput, String reportFileName, String logFileName,
 						double passThreshold, double unstableThreshold,
-						boolean onlyCritical, String otherFiles, boolean enableCache) {
+						boolean onlyCritical, String otherFiles, boolean enableCache, String overwriteXAxisLabel) {
 		this.outputPath = outputPath;
 		this.outputFileName = outputFileName;
 		this.disableArchiveOutput = disableArchiveOutput;
@@ -105,6 +106,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 		this.logFileName = logFileName;
 		this.onlyCritical = onlyCritical;
 		this.enableCache = enableCache;
+		this.overwriteXAxisLabel = overwriteXAxisLabel;
 
 		if (otherFiles != null) {
 			String[] filemasks = otherFiles.split(",");
@@ -201,6 +203,14 @@ public class RobotPublisher extends Recorder implements Serializable,
 	 */
 	public String getOtherFiles() {
 		return StringUtils.join(otherFiles, ",");
+	}
+
+	/**
+	 * Gets the value of overwriteXAxisLabel
+	 * @return X axis label for the trend
+	 */
+	public String getOverwriteXAxisLabel() {
+		return overwriteXAxisLabel;
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/robot/RobotStep.java
+++ b/src/main/java/hudson/plugins/robot/RobotStep.java
@@ -38,6 +38,7 @@ public class RobotStep extends Step {
 	private @CheckForNull String[] otherFiles;
 	private boolean enableCache = true;
 	private boolean onlyCritical = true;
+	private @CheckForNull String overwriteXAxisLabel;
 
 	
 	
@@ -88,6 +89,10 @@ public class RobotStep extends Step {
 	
 	public boolean getOnlyCritical() {
 		return this.onlyCritical;
+	}
+
+	public String getOverwriteXAxisLabel() {
+		return this.overwriteXAxisLabel;
 	}
 	
 	@DataBoundSetter
@@ -140,6 +145,11 @@ public class RobotStep extends Step {
 			}
 			this.otherFiles = filemasks;
 		}
+	}
+
+	@DataBoundSetter
+	public void setOverwriteXAxisLabel(String overwriteXAxisLabel) {
+		this.overwriteXAxisLabel = overwriteXAxisLabel;
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/robot/RobotStepExecution.java
+++ b/src/main/java/hudson/plugins/robot/RobotStepExecution.java
@@ -28,7 +28,7 @@ public class RobotStepExecution extends SynchronousNonBlockingStepExecution<Void
     @Override protected Void run() throws Exception {
     	FilePath workspace = getContext().get(FilePath.class);
         workspace.mkdirs();
-    	RobotPublisher rp = new RobotPublisher(step.getOutputPath(), step.getOutputFileName(), step.getDisableArchiveOutput(), step.getReportFileName(), step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), step.getOnlyCritical(), step.getOtherFiles(), step.getEnableCache());
+    	RobotPublisher rp = new RobotPublisher(step.getOutputPath(), step.getOutputFileName(), step.getDisableArchiveOutput(), step.getReportFileName(), step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), step.getOnlyCritical(), step.getOtherFiles(), step.getEnableCache(), step.getOverwriteXAxisLabel());
     	rp.perform(getContext().get(Run.class), workspace, getContext().get(Launcher.class), getContext().get(TaskListener.class));
     	return null;
     }

--- a/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -265,7 +266,8 @@ public class RobotCaseResult extends RobotTestObject{
 	public void doGraph(StaplerRequest req, StaplerResponse rsp)
 			throws IOException {
 		if(!isNeedToGenerate(req, rsp)) return;
-		String labelFormat = RobotConfig.getInstance().getXAxisLabelFormat();
+		String label = getParentAction().getxAxisLabel();
+		String labelFormat = StringUtils.isBlank(label) ? RobotConfig.getInstance().getXAxisLabelFormat() : label;
 		Graph g = RobotGraphHelper.createTestResultsGraphForTestObject(this, false, true,
 				  Boolean.parseBoolean(req.getParameter("hd")), false, false, labelFormat,
 				  Integer.parseInt(req.getParameter("maxBuildsToShow")));

--- a/src/main/java/hudson/plugins/robot/model/RobotTestObject.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotTestObject.java
@@ -253,7 +253,8 @@ public abstract class RobotTestObject extends AbstractModelObject implements Ser
 	public void doGraph(StaplerRequest req, StaplerResponse rsp)
 			throws IOException {
 		if(!isNeedToGenerate(req, rsp)) return;
-		String labelFormat = RobotConfig.getInstance().getXAxisLabelFormat();
+		String label = parentAction.getxAxisLabel();
+		String labelFormat = StringUtils.isBlank(label) ? RobotConfig.getInstance().getXAxisLabelFormat() : label;
 		Graph g = RobotGraphHelper.createTestResultsGraphForTestObject(this,
 				Boolean.parseBoolean(req.getParameter("zoomSignificant")),
 				false, Boolean.parseBoolean(req.getParameter("hd")),
@@ -273,7 +274,8 @@ public abstract class RobotTestObject extends AbstractModelObject implements Ser
 	public void doDurationGraph(StaplerRequest req, StaplerResponse rsp)
 			throws IOException {
 		if(!isNeedToGenerate(req, rsp)) return;
-		String labelFormat = RobotConfig.getInstance().getXAxisLabelFormat();
+		String label = parentAction.getxAxisLabel();
+		String labelFormat = StringUtils.isBlank(label) ? RobotConfig.getInstance().getXAxisLabelFormat() : label;
 		Graph g = RobotGraphHelper.createDurationGraphForTestObject(this,
 				req.hasParameter("hd"),
  				Integer.parseInt(req.getParameter("maxBuildsToShow")),

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
@@ -38,6 +38,9 @@ limitations under the License.
     <f:entry title="${%advanced.enableCache}" description="${%advanced.enableCache.description}" field="enableCache">
         <f:checkbox default="true"/>
     </f:entry>
+    <f:entry title="${%advanced.overwriteXAxisLabel}" description="${%advanced.overwriteXAxisLabel.description}" field="overwriteXAxisLabel">
+      <f:textbox />
+    </f:entry>
   </f:advanced>
   <f:entry title="${%thresholds.label}" help="/plugin/robot/help-thresholds.html">
     <table width="100%">

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
@@ -14,6 +14,9 @@ advanced.otherfiles=Other files to copy
 advanced.otherfiles.description=Comma separated list of robot related artifacts to be saved
 advanced.enableCache=Enable cache
 advanced.enableCache.description=Enable cache for test results
+advanced.overwriteXAxisLabel=X-axis label
+advanced.overwriteXAxisLabel.description=Overwrite default x-axis label for publish trend
+
 
 thresholds.label=Thresholds for build result
 thresholds.onlycritical=Use thresholds for critical tests only

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/help-overwriteXAxisLabel.html
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/help-overwriteXAxisLabel.html
@@ -1,0 +1,18 @@
+<!--
+Copyright 2008-2014 Nokia Solutions and Networks Oy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div>
+    <p>Pattern to format x axis label in trend graphs. You can use $build for build number beside all letters from java class DateTimeFormatter (e.g. MM-dd HH:mm). Already created and cached images are not affected</p>
+</div>

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
@@ -38,6 +38,9 @@ limitations under the License.
     <f:entry title="${%advanced.enableCache}" description="${%advanced.enableCache.description}" field="enableCache">
         <f:checkbox default="true"/>
     </f:entry>
+    <f:entry title="${%advanced.overwriteXAxisLabel}" description="${%advanced.overwriteXAxisLabel.description}" field="overwriteXAxisLabel">
+      <f:textbox />
+    </f:entry>
   </f:advanced>
   <f:entry title="${%thresholds.label}" help="/plugin/robot/help-thresholds.html">
     <table width="100%">

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
@@ -14,6 +14,8 @@ advanced.otherfiles=Other files to copy
 advanced.otherfiles.description=Comma separated list of robot related artifacts to be saved
 advanced.enableCache=Enable cache
 advanced.enableCache.description=Enable cache for test results
+advanced.overwriteXAxisLabel=X-axis label
+advanced.overwriteXAxisLabel.description=Overwrite default x-axis label for publish trend
 
 thresholds.label=Thresholds for build result
 thresholds.onlycritical=Use thresholds for critical tests only

--- a/src/main/resources/hudson/plugins/robot/RobotStep/help-overwriteXAxisLabel.html
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/help-overwriteXAxisLabel.html
@@ -1,0 +1,18 @@
+<!--
+Copyright 2008-2014 Nokia Solutions and Networks Oy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div>
+    <p>Pattern to format x axis label in trend graphs. You can use $build for build number beside all letters from java class DateTimeFormatter (e.g. MM-dd HH:mm). Already created and cached images are not affected</p>
+</div>

--- a/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
@@ -60,7 +60,7 @@ public class RobotProjectActionTest extends TestCase {
 		when(build.getProject()).thenReturn(p);
 		when(build.getRootDir()).thenReturn(tmpDir);
 		RobotResult result = mock(RobotResult.class);
-		RobotBuildAction buildAction = new RobotBuildAction(build, result, "", null, null, null, false);
+		RobotBuildAction buildAction = new RobotBuildAction(build, result, "", null, null, null, false, "");
 		when(build.getAction(RobotBuildAction.class)).thenReturn(buildAction);
 		when(p.getLastBuild()).thenReturn(build);
 
@@ -76,7 +76,7 @@ public class RobotProjectActionTest extends TestCase {
 		when(buildWithAction.getProject()).thenReturn(p);
 		when(buildWithAction.getRootDir()).thenReturn(tmpDir);
 		RobotResult result = mock(RobotResult.class);
-		RobotBuildAction buildAction = new RobotBuildAction(buildWithAction, result, "", null, null, null, false);
+		RobotBuildAction buildAction = new RobotBuildAction(buildWithAction, result, "", null, null, null, false, "");
 		when(buildWithAction.getAction(RobotBuildAction.class)).thenReturn(buildAction);
 
 		when(p.getLastBuild()).thenReturn(lastBuild);

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -57,7 +57,7 @@ public class RobotPublisherSystemTest {
 	public void testRoundTripConfig() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testRoundTripConfig");
 		RobotPublisher before = new RobotPublisher("a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
-				false);
+				false, "");
 		p.getPublishersList().add(before);
 		j.configRoundtrip(p);
 		RobotPublisher after = p.getPublishersList().get(RobotPublisher.class);
@@ -70,7 +70,7 @@ public class RobotPublisherSystemTest {
 	public void testConfigView() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testConfigView");
 		RobotPublisher before = new RobotPublisher("a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
-				false);
+				false, "");
 		p.getPublishersList().add(before);
 		HtmlPage page = j.createWebClient().getPage(p, "configure");
 		WebAssert.assertTextPresent(page, "Publish Robot Framework");

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -38,7 +38,7 @@ public class RobotPublisherTest {
 	}
 
 	private RobotPublisher getRobotPublisher(double passThreshold, double unstableThreshold) {
-		return new RobotPublisher("", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false);
+		return new RobotPublisher("", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false, "");
 	}
 
 	@Test


### PR DESCRIPTION
Currently the x axis label is only customizable globally. This PR allows each job to have a customized x axis label.