### PR TITLE
[JENKINS-63900] - Expand environment variables in freestyle jobs

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -287,7 +287,8 @@ public class RobotPublisher extends Recorder implements Serializable,
 
 				logger.println(Messages.robot_publisher_assigning());
 
-				RobotBuildAction action = new RobotBuildAction(build, result, getArchiveDirName(), listener, expandedReportFileName, expandedLogFileName, enableCache, overwriteXAxisLabel);
+				String label = buildEnv.expand(overwriteXAxisLabel);
+				RobotBuildAction action = new RobotBuildAction(build, result, getArchiveDirName(), listener, expandedReportFileName, expandedLogFileName, enableCache, label);
 				build.addAction(action);
 
 				// set RobotProjectAction as project action


### PR DESCRIPTION
Fix freestyle jobs not expanding environment variables properly when setting x axis label.