### PR TITLE
[JENKINS-64955] - Fix execution times in Blue Ocean

### DIFF
--- a/src/main/java/hudson/plugins/robot/blueocean/BlueRobotTestResult.java
+++ b/src/main/java/hudson/plugins/robot/blueocean/BlueRobotTestResult.java
@@ -37,7 +37,8 @@ public class BlueRobotTestResult extends BlueTestResult {
 
 	@Override
 	public float getDuration() {
-		return result.getDuration();
+		// Blue ocean uses seconds instead of milliseconds
+		return result.getDuration() / (float)1000;
 	}
 
 	@Override


### PR DESCRIPTION
Use seconds instead of milliseconds in Blue Ocean view.