### PR TITLE
[JENKINS-65414] - Ignore case when checking teardown status

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -151,7 +151,7 @@ public class RobotParser {
 						suite.addChild(processSuite(reader, suite, baseDirectory));
 					} else if("test".equals(tagName)){
 						suite.addCaseResult(processTest(reader, suite));
-					} else if("kw".equals(tagName) && "teardown".equals(reader.getAttributeValue(null, "type"))) {
+					} else if("kw".equals(tagName) && "teardown".equalsIgnoreCase(reader.getAttributeValue(null, "type"))) {
 						ignoreUntilStarts(reader, "status");
 						if ("FAIL".equals(reader.getAttributeValue(null, "status"))) {
 							suite.failTeardown();


### PR DESCRIPTION
Robot Framework 4.0 uses `TEARDOWN` instead of `teardown` in teardown keywords causing plugin to mark failed tests as passed. Ignore case when checking teardown status to support 3.x and 4.x.