### PR TITLE
Suite might not have name at all

### DIFF
--- a/src/main/java/hudson/plugins/robot/model/RobotTestObject.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotTestObject.java
@@ -98,7 +98,14 @@ public abstract class RobotTestObject extends AbstractModelObject implements Ser
 	 * @return package name
 	 */
 	public String getRelativePackageName(RobotTestObject thisObject) {
-		StringBuilder sb = new StringBuilder(getName());
+		/*
+		`name` attribute might be missing from suites, see more: https://issues.jenkins.io/browse/JENKINS-69807
+		*/
+		String name = getName();
+		if (name == null){
+			name = "";
+		}
+		StringBuilder sb = new StringBuilder(name);
 		String parentPackage = getRelativeParent(thisObject);
 		if (! "".equals(parentPackage)) {
 			sb.insert(0, parentPackage);

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
@@ -326,5 +329,23 @@ public class RobotResultTest {
 		RobotCaseResult caseResult = (RobotCaseResult)result.findObjectById("Skip/Test 8 Will Always Fail");
 		String tags = StringUtils.join(caseResult.getTags(), ",");
 		assertEquals("fail,tag2,tag3", tags);
+	}
+
+	@Test
+	public void testSuiteNameAttributeMightBeMissingInRobot4() throws Exception {
+		/**
+		 * see more: https://issues.jenkins.io/browse/JENKINS-69807
+		 **/
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("robot4_empty_suite_name.xml", null, null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("robot4_empty_suite_name.xml").toURI()).getParentFile(), null);
+
+		RobotSuiteResult r = result.getSuites().iterator().next();
+		r = r.getChildSuites().iterator().next();
+		RobotCaseResult caseResult = r.getCaseResults().iterator().next();
+
+		// passing null as `thisObject` should not matter, as the name resolving fails first
+		// due to getName() returning `null`
+		caseResult.getRelativePackageName(null);
+
 	}
 }

--- a/src/test/resources/hudson/plugins/robot/model/robot4_empty_suite_name.xml
+++ b/src/test/resources/hudson/plugins/robot/model/robot4_empty_suite_name.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 4.0 (Python 3.9.13 on darwin)" generated="20221012 15:34:38.101" rpa="false" schemaversion="2">
+<suite id="s1" name="Empty Suite Attribute" source="/Users/tkairi/tmp/empty_suite_attribute">
+<suite id="s1-s1" source="/Users/tkairi/tmp/empty_suite_attribute/a_test_suite__.robot">
+<test id="s1-s1-t1" name="TC">
+<kw name="No Operation" library="BuiltIn">
+<doc>Does absolutely nothing.</doc>
+<status status="PASS" starttime="20221012 15:34:38.112" endtime="20221012 15:34:38.112"/>
+</kw>
+<status status="PASS" starttime="20221012 15:34:38.111" endtime="20221012 15:34:38.112"/>
+</test>
+<status status="PASS" starttime="20221012 15:34:38.111" endtime="20221012 15:34:38.112"/>
+</suite>
+<status status="PASS" starttime="20221012 15:34:38.102" endtime="20221012 15:34:38.112"/>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="1" fail="0" skip="0" id="s1" name="Empty Suite Attribute">Empty Suite Attribute</stat>
+<stat pass="1" fail="0" skip="0" id="s1-s1">Empty Suite Attribute.</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>


### PR DESCRIPTION
Fixes [JENKINS-69807](https://issues.jenkins.io/browse/JENKINS-69807)

In RF4, suite name in output.xml might be non-existent in some cases (see more below [*]). In these cases, `RobotTestObject.getName()` returned null as well, which became problem for `RobotTestObject.getRelativePackageName()`.

Handle null from `getName()` as an empty string.

[*] RF uses double underscore ('__') in suite name as a separator as per https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-suite-name-and-documentation

If user has named their suite so it ends with double undercore (eg. suite__.robot), suite name is of course empty. Before RF5, this meant output.xml's <suite> tag did not get name-attribute at all; hence the null.