### PR TITLE
Add Robot Framework 7.0 support

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -287,7 +287,6 @@ public class RobotParser {
 
 		private RobotCaseResult processTest(XMLStreamReader reader, RobotSuiteResult result) throws XMLStreamException {
 			RobotCaseResult caseResult = new RobotCaseResult();
-			caseResult.setSchemaVersion(schemaVersion);
 			caseResult.setParent(result);
 			caseResult.setLogFile(this.logFileName);
 			//parse attributes
@@ -342,6 +341,9 @@ public class RobotParser {
 
 			caseResult.setStarttime(reader.getAttributeValue(null, startLocalName));
 			caseResult.setEndtime(reader.getAttributeValue(null, endLocalName));
+			if (schemaVersion >= 5) {
+				caseResult.setElapsedTime(reader.getAttributeValue(null, elapsedLocalName));
+			}
 			setCriticalityIfAvailable(reader, caseResult);
 			while(reader.hasNext()){
 				reader.next();

--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -124,6 +124,8 @@ public class RobotParser {
 						String value = reader.getAttributeValue(null, "schemaversion");
 						value = value == null ? "0" : value;
 						schemaVersion = Integer.parseInt(value);
+// RF schemaVersion does not follow major version number. 
+// schemaVersion 5 == RF7.0 
 						if (schemaVersion >= 5) {
 							startLocalName = "start";
 							elapsedLocalName = "elapsed";

--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -57,6 +57,11 @@ public class RobotParser {
 		private final String logFileName;
 		private final String reportFileName;
 
+		private int schemaVersion;
+		private String startLocalName = "starttime";
+		private String elapsedLocalName = "elapsedtime";
+		private String endLocalName = "endtime";
+
 		public RobotParserCallable(String outputFileLocations, String logFileName, String reportFileName) {
 			this.outputFileLocations = outputFileLocations;
 			this.logFileName = logFileName;
@@ -116,6 +121,14 @@ public class RobotParser {
 						//we already have all data from suites and tests so we can stop parsing
 						break;
 					else if("robot".equals(tagName)){
+						String value = reader.getAttributeValue(null, "schemaversion");
+						value = value == null ? "0" : value;
+						schemaVersion = Integer.parseInt(value);
+						if (schemaVersion >= 5) {
+							startLocalName = "start";
+							elapsedLocalName = "elapsed";
+							// endLocalName is no longer used
+						}
 						result.setTimeStamp(reader.getAttributeValue(null, "generated"));
 					} else if("suite".equals(tagName)){
 						result.addSuite(processSuite(reader, result, baseDirectory));
@@ -131,6 +144,7 @@ public class RobotParser {
 				return getSplitXMLSuite(parent, baseDirectory, splitXMLPath);
 			}
 			RobotSuiteResult suite = new RobotSuiteResult();
+			suite.setSchemaVersion(schemaVersion);
 			suite.setLogFile(this.logFileName);
 			suite.setReportFile(this.reportFileName);
 			suite.setParent(parent);
@@ -157,9 +171,9 @@ public class RobotParser {
 							suite.failTeardown();
 						}
 					} else if("status".equals(tagName)){
-						suite.setElapsedTime(reader.getAttributeValue(null, "elapsedtime"));
-						suite.setStartTime(reader.getAttributeValue(null, "starttime"));
-						suite.setEndTime(reader.getAttributeValue(null, "endtime"));
+						suite.setElapsedTime(reader.getAttributeValue(null, elapsedLocalName));
+						suite.setStartTime(reader.getAttributeValue(null, startLocalName));
+						suite.setEndTime(reader.getAttributeValue(null, endLocalName));
 					}
 				} else if (reader.isEndElement() && "suite".equals(reader.getLocalName())) {
 					return suite;
@@ -273,6 +287,7 @@ public class RobotParser {
 
 		private RobotCaseResult processTest(XMLStreamReader reader, RobotSuiteResult result) throws XMLStreamException {
 			RobotCaseResult caseResult = new RobotCaseResult();
+			caseResult.setSchemaVersion(schemaVersion);
 			caseResult.setParent(result);
 			caseResult.setLogFile(this.logFileName);
 			//parse attributes
@@ -324,8 +339,9 @@ public class RobotParser {
 			//parse test details from nested status
 			caseResult.setPassed("PASS".equals(reader.getAttributeValue(null, "status")));
 			caseResult.setSkipped("SKIP".equals(reader.getAttributeValue(null, "status")));
-			caseResult.setStarttime(reader.getAttributeValue(null, "starttime"));
-			caseResult.setEndtime(reader.getAttributeValue(null, "endtime"));
+
+			caseResult.setStarttime(reader.getAttributeValue(null, startLocalName));
+			caseResult.setEndtime(reader.getAttributeValue(null, endLocalName));
 			setCriticalityIfAvailable(reader, caseResult);
 			while(reader.hasNext()){
 				reader.next();

--- a/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
@@ -47,11 +47,14 @@ public class RobotCaseResult extends RobotTestObject{
 	private String description;
 	private String starttime;
 	private String endtime;
+	private double elapsedtime;
 	private List<String> tags;
 	private String stackTrace;
 
 	private RobotSuiteResult parent;
 	private int failedSince;
+
+	private int schemaVersion;
 
 	/**
 	 * Difference between string timevalues in format yyyyMMdd HH:mm:ss.SS (Java DateFormat).
@@ -61,9 +64,10 @@ public class RobotCaseResult extends RobotTestObject{
 	 * @return Elapsed time from start to end
 	 * @throws ParseException thrown exception
 	 */
-	public static long timeDifference(String time1, String time2) throws ParseException{
+	public static long timeDifference(String time1, String time2) throws ParseException {
 		long difference = 0;
-		DateFormat format = new SimpleDateFormat("yyyyMMdd HH:mm:ss.SS");
+		String dateFormat = "yyyyMMdd HH:mm:ss.SS";
+		DateFormat format = new SimpleDateFormat(dateFormat);
 
 		Date startDate = format.parse(time1);
 		Date endDate = format.parse(time2);
@@ -83,7 +87,7 @@ public class RobotCaseResult extends RobotTestObject{
 	public void setName(String name) {
 		this.name = name;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -137,6 +141,14 @@ public class RobotCaseResult extends RobotTestObject{
 		this.endtime = endtime;
 	}
 
+	public double getElapsedtime() {
+		return elapsedtime;
+	}
+
+	public void setElapsedTime(String elapsed) {
+		this.elapsedtime = Double.parseDouble(elapsed);
+	}
+
 	public String getErrorMsg() {
 		return errorMsg;
 	}
@@ -144,7 +156,7 @@ public class RobotCaseResult extends RobotTestObject{
 	public void setErrorMsg(String errorMsg) {
 		this.errorMsg = errorMsg;
 	}
-	
+
 	public String getStackTrace() {
 		return stackTrace;
 	}
@@ -163,6 +175,10 @@ public class RobotCaseResult extends RobotTestObject{
 
 	public void setCritical(boolean critical) {
 		this.critical = critical;
+	}
+
+	public void setSchemaVersion(int version) {
+		this.schemaVersion = version;
 	}
 
 	public String getDisplayName() {

--- a/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
@@ -54,8 +54,6 @@ public class RobotCaseResult extends RobotTestObject{
 	private RobotSuiteResult parent;
 	private int failedSince;
 
-	private int schemaVersion;
-
 	/**
 	 * Difference between string timevalues in format yyyyMMdd HH:mm:ss.SS (Java DateFormat).
 	 * Difference is calculated time2 - time1.
@@ -116,7 +114,8 @@ public class RobotCaseResult extends RobotTestObject{
 	public long getDuration() {
 		if (duration != 0)
 			return duration;
-
+		if (elapsedtime != 0)
+			return Double.valueOf(elapsedtime * 1000).longValue(); // convert seconds to milliseconds
 		try{
 			return timeDifference(this.starttime, this.endtime);
 		} catch (ParseException e){
@@ -175,10 +174,6 @@ public class RobotCaseResult extends RobotTestObject{
 
 	public void setCritical(boolean critical) {
 		this.critical = critical;
-	}
-
-	public void setSchemaVersion(int version) {
-		this.schemaVersion = version;
 	}
 
 	public String getDisplayName() {

--- a/src/main/java/hudson/plugins/robot/model/RobotSuiteResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotSuiteResult.java
@@ -49,6 +49,8 @@ public class RobotSuiteResult extends RobotTestObject {
 	private transient int criticalPassed;
 	private transient int criticalFailed;
 
+	private int schemaVersion;
+
 
 	/**
 	 * Adds a nested suite to this suite. If a suite exists with the same name
@@ -122,7 +124,7 @@ public class RobotSuiteResult extends RobotTestObject {
 	public Collection<RobotCaseResult> getCaseResults() {
 		if(caseResults != null) {
 			List<RobotCaseResult> res = new ArrayList(caseResults.values());
-			Collections.sort(res, new RobotCaseComparator());
+			res.sort(new RobotCaseComparator());
 			return res;
 		}
 		return Collections.emptyList();
@@ -180,6 +182,10 @@ public class RobotSuiteResult extends RobotTestObject {
 		return criticalPassed + criticalFailed;
 	}
 
+	public void setSchemaVersion(int version) {
+		this.schemaVersion = version;
+	}
+
 	/**
 	 * Adds a test case result to this suite. If a case exists with the same
 	 * name it will be overwritten with this one.
@@ -202,7 +208,7 @@ public class RobotSuiteResult extends RobotTestObject {
 	public void setElapsedTime(String elapsedTime) {
 		this.elapsedTime = elapsedTime;
 	}
-	
+
 	public void setStartTime(String startTime){
 		this.startTime = startTime;
 	}
@@ -213,6 +219,10 @@ public class RobotSuiteResult extends RobotTestObject {
 
 	@Override
 	public long getDuration() {
+		if (schemaVersion >= 5) {
+			double d = Double.parseDouble(this.elapsedTime) * 1000;
+			return Double.valueOf(d).longValue();
+		}
 		if (StringUtils.isNotEmpty(this.elapsedTime)) {
 			return Long.parseLong(this.elapsedTime);
 		} else if (StringUtils.isEmpty(this.startTime) || StringUtils.isEmpty(this.endTime)) {

--- a/src/test/java/hudson/plugins/robot/RobotParserTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotParserTest.java
@@ -202,4 +202,11 @@ public class RobotParserTest {
         final String mask = "empty_args-output.xml";
         parse(dir, mask);
     }
+
+    @Test
+    public void testRF7InlineVar() {
+        final String dir = "robot7";
+        final String mask = "inline_var_output.xml";
+        parse(dir, mask);
+    }
 }

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -17,20 +17,15 @@ package hudson.plugins.robot.model;
 
 import hudson.plugins.robot.RobotParser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
+import hudson.plugins.robot.RobotParserTest;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 
 public class RobotResultTest {
@@ -346,6 +341,24 @@ public class RobotResultTest {
 		// passing null as `thisObject` should not matter, as the name resolving fails first
 		// due to getName() returning `null`
 		caseResult.getRelativePackageName(null);
+	}
 
+	@Test
+	public void testCaseResultsShouldBeCorrectlySet() throws  Exception {
+		File directory = new File(RobotParserTest.class.getResource("robot7").toURI());
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("inline_var_output.xml", null, null);
+		result = remoteOperation.invoke(directory, null);
+		result.tally(null);
+
+		RobotSuiteResult suite = result.getSuite("Rf7");
+		RobotCaseResult caseResult = suite.getCase("Test Inline Var");
+
+		// suite results
+		assertEquals(35.0, suite.getDuration(), 0.01);
+
+		// case results
+		assertEquals("2023-11-13T15:33:07.168330", caseResult.getStarttime());
+		assertEquals(0.001748, caseResult.getElapsedtime(), 0.01);
+		assertNull(caseResult.getEndtime());
 	}
 }

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -75,7 +75,7 @@ public class RobotResultTest {
 		RobotCaseResult caseResult = suite.getCase("Hello");
 		assertNotNull(caseResult);
 	}
-	
+
 	@Test
 	public void testShouldParseCaseDescription(){
 		RobotSuiteResult suite = result.getSuite("Othercases & Testcases");
@@ -111,7 +111,7 @@ public class RobotResultTest {
 		String errorMsg = caseResult.getErrorMsg();
 		assertEquals("Test failed miserably!", errorMsg.trim());
 	}
-	
+
 	@Test
 	public void testShouldParseNewCriticalCases() throws Exception{
 

--- a/src/test/resources/hudson/plugins/robot/robot7/inline_var_output.xml
+++ b/src/test/resources/hudson/plugins/robot/robot7/inline_var_output.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.0a1 (Python 3.8.5 on darwin)" generated="2023-11-13T15:33:07.131714" rpa="false" schemaversion="5">
+<suite id="s1" name="Rf7" source="/Users/aleksisimell/projects/tmp/rf7.robot">
+<test id="s1-t1" name="Test Inline Var" line="2">
+<variable name="${local}">
+<var>mikki hiiri</var>
+<status status="PASS" start="2023-11-13T15:33:07.168900" elapsed="0.000162"/>
+</variable>
+<kw name="Should Be Equal" owner="BuiltIn">
+<arg>${local}</arg>
+<arg>mikki hiiri</arg>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" start="2023-11-13T15:33:07.169409" elapsed="0.000416"/>
+</kw>
+<status status="PASS" start="2023-11-13T15:33:07.168330" elapsed="0.001748"/>
+</test>
+<status status="PASS" start="2023-11-13T15:33:07.134805" elapsed="0.035963"/>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="1" fail="0" skip="0" id="s1" name="Rf7">Rf7</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>


### PR DESCRIPTION
Modify parser and other necessary classes to support new `start` and `elapsed` attributes while maintaining support for earlier Robot Framework versions.

https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-7.0a2.rst#changes-to-outputxml