### PR TITLE
Add a log message to inform deprecation of critical checks

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -254,6 +254,7 @@ public class RobotPublisher extends Recorder implements Serializable,
 		if (build.getResult() != Result.ABORTED) {
 			PrintStream logger = listener.getLogger();
 			logger.println(Messages.robot_publisher_started());
+			logger.println(Messages.robot_publisher_only_critical());
 			logger.println(Messages.robot_publisher_parsing());
 			RobotResult result;
 

--- a/src/main/resources/hudson/plugins/robot/Messages.properties
+++ b/src/main/resources/hudson/plugins/robot/Messages.properties
@@ -23,6 +23,7 @@ robot.publisher.finished=Done publishing Robot results.
 robot.publisher.done= Done!
 robot.publisher.fail= Failed!
 
+robot.publisher.only_critical=INFO: Checking test criticality is deprecated and will be dropped in a future release!
 robot.publisher.file_not_found=WARNING! Could not find file:
 
 robot.config.percentvalidation=Entry must be percentage value between 0-100


### PR DESCRIPTION
Test criticality was dropped in RF 4.0. Prepare the plugin to drop support for RF 3.x and lower.