### PR TITLE
JENKINS-63900 - Add possibility to use build display name as graph label

### DIFF
--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -124,8 +124,8 @@ public class RobotParser {
 						String value = reader.getAttributeValue(null, "schemaversion");
 						value = value == null ? "0" : value;
 						schemaVersion = Integer.parseInt(value);
-// RF schemaVersion does not follow major version number. 
-// schemaVersion 5 == RF7.0 
+						// RF schemaVersion does not follow major version number.
+						// schemaVersion 5 == RF7.0
 						if (schemaVersion >= 5) {
 							startLocalName = "start";
 							elapsedLocalName = "elapsed";

--- a/src/main/java/hudson/plugins/robot/graph/RobotBuildLabel.java
+++ b/src/main/java/hudson/plugins/robot/graph/RobotBuildLabel.java
@@ -19,6 +19,7 @@ public class RobotBuildLabel implements Comparable<RobotBuildLabel>
 
     private String formatBuildLabel(String format, Date startTime) {
         String pattern = format.replace("$build",""+run.number);
+        pattern = pattern.replace("$display_name", run.getDisplayName());
         return new SimpleDateFormat(pattern).format(startTime);
     }
 

--- a/src/test/java/hudson/plugins/robot/graph/RobotGraphHelperTest.java
+++ b/src/test/java/hudson/plugins/robot/graph/RobotGraphHelperTest.java
@@ -51,6 +51,8 @@ public class RobotGraphHelperTest extends TestCase {
 		c.setTimeInMillis(0L);
 		when(mockBuild1.getTimestamp()).thenReturn(c);
 		when(mockBuild2.getTimestamp()).thenReturn(c);
+		when(mockBuild1.getDisplayName()).thenReturn("build 1");
+		when(mockBuild2.getDisplayName()).thenReturn("build 2");
 
 		// set up some results chains
 		mockResult1 = spy(result);


### PR DESCRIPTION
#18 introduced the possibility to use build time as the graph label, but at the same time it removed the possibility to use build display name as the label. This PR reintroduces that possibility.