### PR TITLE
JENKINS-72538 - `SKIP` status configurable when calculating all tests

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -178,22 +178,14 @@ and [here](https://content-security-policy.com/) how to change you CSP settings 
 but be aware that **Changing CSP settings will potentially expose you Jenkins instance for
 security vulnerabilities**.
 
-### Robot Framework 4.x compatibility
+### Robot Framework 4.x+ compatibility
 
-The plugin supports both Robot Framework 3.x and 4.x output files. However, in order to support both, the plugin
-shows some extra information for both. [In Robot Framework 4.0 test criticality was removed and "SKIP" status was added](https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-4.0.rst). So for 3.x the
-results overview will show a `Skipped` column, which will always be 0 and for Robot Framework 4.x output files
-the `Critical tests` row will always be 0.
+:heavy_exclamation_mark: As we're preparing to drop support for RF 3.x, the `onlyCritical` flag has been deprecated and no
+longer has any effect. It will be removed in the future, but for now it's available for the transition period.
+A new flag `countSkippedTests` has been added to the pipeline step to allow users to choose whether to count skipped
+tests in the pass percentage calculation.
 
-Skipped tests aren't taken into account when calculating pass percentage, but they are calculated to the total
-amount of tests.
-
-Because criticality was removed in Robot Framework 4.0, having the `Use thresholds for critical tests only` checkbox
-checked will always result in a passing step (because pass percentage is always considered to be 100% when there are
-0 tests). In order to have set build status correctly, you **must** uncheck the checkbox or use `onlyCritical: false`
-in your pipeline when you call `robot`.
-
-We are planning of dropping support for Robot Framework 3.x and earlier some time in distant future.
+The plugin still supports RF 3.x, but no longer takes criticality into account.
 
 ### Overall Screenshots
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -185,7 +185,7 @@ longer has any effect. It will be removed in the future, but for now it's availa
 A new flag `countSkippedTests` has been added to the pipeline step to allow users to choose whether to count skipped
 tests in the pass percentage calculation.
 
-The plugin still supports RF 3.x, but no longer takes criticality into account.
+The plugin still supports RF 3.x, but no longer takes criticality into account. If you want to use RF 3.x with criticality, please downgrade to the last major version (4.0.0)
 
 ### Overall Screenshots
 

--- a/src/main/java/hudson/plugins/robot/AggregatedRobotAction.java
+++ b/src/main/java/hudson/plugins/robot/AggregatedRobotAction.java
@@ -109,33 +109,34 @@ public class AggregatedRobotAction implements Action {
 
 		private static final long serialVersionUID = 1L;
 		private final transient AggregatedRobotAction parent;
-		private int passed, failed, skipped, criticalPassed, criticalFailed;
+		private int passed, failed, skipped;
 
 		public AggregatedRobotResult(AggregatedRobotAction parent) {
 			this.parent = parent;
 		}
 
 		public void addResult(RobotResult result) {
-			criticalFailed += result.getCriticalFailed();
-			criticalPassed += result.getCriticalPassed();
 			failed += result.getOverallFailed();
 			passed += result.getOverallPassed();
 			skipped += result.getOverallSkipped();
 		}
 
+		@Deprecated
 		@Override
 		public long getCriticalPassed() {
-			return criticalPassed;
+			return this.getOverallPassed();
 		}
 
+		@Deprecated
 		@Override
 		public long getCriticalFailed() {
-			return criticalFailed;
+			return this.getOverallFailed();
 		}
 
+		@Deprecated
 		@Override
 		public long getCriticalTotal() {
-			return criticalFailed + criticalPassed;
+			return this.getOverallTotal();
 		}
 
 		@Override

--- a/src/main/java/hudson/plugins/robot/RobotBuildAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotBuildAction.java
@@ -65,6 +65,8 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	private RobotResult result;
 	private String xAxisLabel;
 
+	private boolean countSkippedTests;
+
 	static {
 		XSTREAM.alias("result",RobotResult.class);
 		XSTREAM.alias("suite",RobotSuiteResult.class);
@@ -83,7 +85,8 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	 * @param enableCache Whether we want to enable caching or not
 	 */
 	public RobotBuildAction(Run<?, ?> build, RobotResult result,
-			String outputPath, TaskListener listener, String logFileLink, String logHtmlLink, boolean enableCache, String xAxisLabel) {
+			String outputPath, TaskListener listener, String logFileLink, String logHtmlLink, boolean enableCache, String xAxisLabel,
+							boolean countSkippedTests) {
 		super();
 		super.onAttached(build);
 		this.build = build;
@@ -92,6 +95,7 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 		this.logHtmlLink = logHtmlLink;
 		this.enableCache = enableCache;
 		this.xAxisLabel = xAxisLabel;
+		this.countSkippedTests = countSkippedTests;
 		setResult(result, listener);
 	}
 
@@ -332,5 +336,13 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 
 	public List<RobotCaseResult> getAllTests() {
 		return getResult().getAllCases();
+	}
+
+	public boolean isCountSkippedTests() {
+		return countSkippedTests;
+	}
+
+	public void setCountSkippedTests(boolean countSkippedTests) {
+		this.countSkippedTests = countSkippedTests;
 	}
 }

--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -293,7 +293,7 @@ public class RobotParser {
 			caseResult.setLogFile(this.logFileName);
 			//parse attributes
 			caseResult.setName(reader.getAttributeValue(null, "name"));
-			setCriticalityIfAvailable(reader, caseResult);
+			//setCriticalityIfAvailable(reader, caseResult);
 			caseResult.setId(reader.getAttributeValue(null, "id"));
 			//parse test tags
 			caseResult.setDescription("");
@@ -346,7 +346,7 @@ public class RobotParser {
 			if (schemaVersion >= 5) {
 				caseResult.setElapsedTime(reader.getAttributeValue(null, elapsedLocalName));
 			}
-			setCriticalityIfAvailable(reader, caseResult);
+//			setCriticalityIfAvailable(reader, caseResult);
 			while(reader.hasNext()){
 				reader.next();
 				if(reader.isCharacters()){

--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -47,450 +47,468 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RobotPublisher extends Recorder implements Serializable,
-		MatrixAggregatable, SimpleBuildStep {
+        MatrixAggregatable, SimpleBuildStep {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	protected static final String DEFAULT_REPORT_FILE = "report.html";
-	protected static final String DEFAULT_ARCHIVE_DIR = "robot-plugin";
-	protected static final String DEFAULT_JENKINS_ARCHIVE_DIR = "archive";
+    protected static final String DEFAULT_REPORT_FILE = "report.html";
+    protected static final String DEFAULT_ARCHIVE_DIR = "robot-plugin";
+    protected static final String DEFAULT_JENKINS_ARCHIVE_DIR = "archive";
 
-	private static final String DEFAULT_OUTPUT_FILE = "output.xml";
-	private static final String DEFAULT_LOG_FILE = "log.html";
+    private static final String DEFAULT_OUTPUT_FILE = "output.xml";
+    private static final String DEFAULT_LOG_FILE = "log.html";
 
-	final private String archiveDirName;
-	final private String outputPath;
-	final private String reportFileName;
-	final private String logFileName;
-	final private String outputFileName;
-	final private boolean disableArchiveOutput;
-	final private double passThreshold;
-	final private double unstableThreshold;
-	private String[] otherFiles;
-	final private String overwriteXAxisLabel;
-	final private boolean enableCache;
+    final private String archiveDirName;
+    final private String outputPath;
+    final private String reportFileName;
+    final private String logFileName;
+    final private String outputFileName;
+    final private boolean disableArchiveOutput;
+    final private double passThreshold;
+    final private double unstableThreshold;
+    private String[] otherFiles;
+    final private String overwriteXAxisLabel;
+    final private boolean enableCache;
 
-	//Default to true
-	private boolean onlyCritical = true;
+    //Default to true
+    private boolean onlyCritical = true;
+    private boolean countSkippedTests = false;
 
-	/**
-	 * Create new publisher for Robot Framework results
-	 *
-	 * @param archiveDirName
-	 *			Name of Archive dir
-	 * @param outputPath
-	 *			Path to Robot Framework's output files
-	 * @param outputFileName
-	 *			Name of Robot output xml
-	 * @param disableArchiveOutput
-	 *			Disable Archiving output xml file to server
-	 * @param reportFileName
-	 *			Name of Robot report html
-	 * @param logFileName
-	 *			Name of Robot log html
-	 * @param passThreshold
-	 *			Threshold of test pass percentage for successful builds
-	 * @param unstableThreshold
-	 *			Threshold of test pass percentage for unstable builds
-	 * @param onlyCritical
-	 *			True if only critical tests are included in pass percentage
-	 * @param otherFiles
-	 * 			Other files to be saved
-	 * @param enableCache
-	 * 			True if caching is used
-	 */
-	@DataBoundConstructor
-	public RobotPublisher(String archiveDirName, String outputPath, String outputFileName,
-						  boolean disableArchiveOutput, String reportFileName, String logFileName,
-						  double passThreshold, double unstableThreshold,
-						  boolean onlyCritical, String otherFiles, boolean enableCache, String overwriteXAxisLabel) {
-		this.archiveDirName = archiveDirName;
-		this.outputPath = outputPath;
-		this.outputFileName = outputFileName;
-		this.disableArchiveOutput = disableArchiveOutput;
-		this.reportFileName = reportFileName;
-		this.passThreshold = passThreshold;
-		this.unstableThreshold = unstableThreshold;
-		this.logFileName = logFileName;
-		this.onlyCritical = onlyCritical;
-		this.enableCache = enableCache;
-		this.overwriteXAxisLabel = overwriteXAxisLabel;
+    /**
+     * Create new publisher for Robot Framework results
+     *
+     * @param archiveDirName       Name of Archive dir
+     * @param outputPath           Path to Robot Framework's output files
+     * @param outputFileName       Name of Robot output xml
+     * @param disableArchiveOutput Disable Archiving output xml file to server
+     * @param reportFileName       Name of Robot report html
+     * @param logFileName          Name of Robot log html
+     * @param passThreshold        Threshold of test pass percentage for successful builds
+     * @param unstableThreshold    Threshold of test pass percentage for unstable builds
+     * @param onlyCritical         True if only critical tests are included in pass percentage
+     * @param otherFiles           Other files to be saved
+     * @param enableCache          True if caching is used
+     */
+    @DataBoundConstructor
+    public RobotPublisher(String archiveDirName, String outputPath, String outputFileName,
+                          boolean disableArchiveOutput, String reportFileName, String logFileName,
+                          double passThreshold, double unstableThreshold,
+                          boolean onlyCritical, boolean countSkippedTests, String otherFiles, boolean enableCache, String overwriteXAxisLabel) {
+        this.archiveDirName = archiveDirName;
+        this.outputPath = outputPath;
+        this.outputFileName = outputFileName;
+        this.disableArchiveOutput = disableArchiveOutput;
+        this.reportFileName = reportFileName;
+        this.passThreshold = passThreshold;
+        this.unstableThreshold = unstableThreshold;
+        this.logFileName = logFileName;
+        this.onlyCritical = onlyCritical;
+        this.countSkippedTests = countSkippedTests;
+        this.enableCache = enableCache;
+        this.overwriteXAxisLabel = overwriteXAxisLabel;
 
-		if (otherFiles != null) {
-			String[] filemasks = otherFiles.split(",");
-			for (int i = 0; i < filemasks.length; i++){
-				filemasks[i] = StringUtils.strip(filemasks[i]);
-			}
-			this.otherFiles = filemasks;
-		}
-	}
+        if (otherFiles != null) {
+            String[] filemasks = otherFiles.split(",");
+            for (int i = 0; i < filemasks.length; i++) {
+                filemasks[i] = StringUtils.strip(filemasks[i]);
+            }
+            this.otherFiles = filemasks;
+        }
+    }
 
-	/**
-	 * Gets the name of archive dir. Reverts to default if empty or
-	 * whitespace.
-	 * @return the name of archive dir
-	 */
-	public String getArchiveDirName() {
-		if (StringUtils.isBlank(archiveDirName))
-			return DEFAULT_ARCHIVE_DIR;
-		return archiveDirName;
-	}
+    /**
+     * Gets the name of archive dir. Reverts to default if empty or
+     * whitespace.
+     *
+     * @return the name of archive dir
+     */
+    public String getArchiveDirName() {
+        if (StringUtils.isBlank(archiveDirName))
+            return DEFAULT_ARCHIVE_DIR;
+        return archiveDirName;
+    }
 
-	/**
-	 * Gets the output path of Robot files
-	 * @return the output path of Robot files
-	 */
-	public String getOutputPath() {
-		return outputPath;
-	}
+    /**
+     * Gets the output path of Robot files
+     *
+     * @return the output path of Robot files
+     */
+    public String getOutputPath() {
+        return outputPath;
+    }
 
-	/**
-	 * Gets the name of output xml file. Reverts to default if empty or
-	 * whitespace.
-	 * @return the name of output xml file
-	 */
-	public String getOutputFileName() {
-		if (StringUtils.isBlank(outputFileName))
-			return DEFAULT_OUTPUT_FILE;
-		return outputFileName;
-	}
+    /**
+     * Gets the name of output xml file. Reverts to default if empty or
+     * whitespace.
+     *
+     * @return the name of output xml file
+     */
+    public String getOutputFileName() {
+        if (StringUtils.isBlank(outputFileName))
+            return DEFAULT_OUTPUT_FILE;
+        return outputFileName;
+    }
 
-	/**
-	 * Get the value of disable Archive of output xml checkbox
-	 * @return the value of disable Archive of output xml checkbox
-	 */
-	public boolean getDisableArchiveOutput() {
-		return disableArchiveOutput;
-	}
+    /**
+     * Get the value of disable Archive of output xml checkbox
+     *
+     * @return the value of disable Archive of output xml checkbox
+     */
+    public boolean getDisableArchiveOutput() {
+        return disableArchiveOutput;
+    }
 
-	/**
-	 * Gets the name of report html file. Reverts to default if empty or
-	 * whitespace.
-	 * @return the name of report html file
-	 */
-	public String getReportFileName() {
-		if (StringUtils.isBlank(reportFileName))
-			return DEFAULT_REPORT_FILE;
-		return reportFileName;
-	}
+    /**
+     * Gets the name of report html file. Reverts to default if empty or
+     * whitespace.
+     *
+     * @return the name of report html file
+     */
+    public String getReportFileName() {
+        if (StringUtils.isBlank(reportFileName))
+            return DEFAULT_REPORT_FILE;
+        return reportFileName;
+    }
 
-	/**
-	 * Gets the name of log html file. Reverts to default if empty or
-	 * whitespace.
-	 * @return the name of log html file
-	 */
-	public String getLogFileName() {
-		if (StringUtils.isBlank(logFileName))
-			return DEFAULT_LOG_FILE;
-		return logFileName;
-	}
+    /**
+     * Gets the name of log html file. Reverts to default if empty or
+     * whitespace.
+     *
+     * @return the name of log html file
+     */
+    public String getLogFileName() {
+        if (StringUtils.isBlank(logFileName))
+            return DEFAULT_LOG_FILE;
+        return logFileName;
+    }
 
-	/**
-	 * Gets the test pass percentage threshold for successful builds.
-	 * @return the test pass percentage threshold for successful builds
-	 */
-	public double getPassThreshold() {
-		return passThreshold;
-	}
+    /**
+     * Gets the test pass percentage threshold for successful builds.
+     *
+     * @return the test pass percentage threshold for successful builds
+     */
+    public double getPassThreshold() {
+        return passThreshold;
+    }
 
-	/**
-	 * Gets the test pass percentage threshold for unstable builds.
-	 * @return the test pass percentage threshold for unstable builds
-	 */
-	public double getUnstableThreshold() {
-		return unstableThreshold;
-	}
+    /**
+     * Gets the test pass percentage threshold for unstable builds.
+     *
+     * @return the test pass percentage threshold for unstable builds
+     */
+    public double getUnstableThreshold() {
+        return unstableThreshold;
+    }
 
-	/**
-	 * Gets if only critical tests should be accounted for the thresholds.
-	 * @return true if only critical tests should be accounted for the thresholds
-	 */
-	public boolean getOnlyCritical() {
-		return onlyCritical;
-	}
+    /**
+     * Gets if only critical tests should be accounted for the thresholds.
+     *
+     * @return true if only critical tests should be accounted for the thresholds
+     */
+    public boolean getOnlyCritical() {
+        return onlyCritical;
+    }
 
-	/**
-	 * Gets value of enableCache
-	 * @return true if cache is enabled
-	 */
-	public boolean getEnableCache() { return enableCache; }
+    /**
+     * Gets if skipped tests should be counted in the thresholds.
+     *
+     * @return true if skipped tests should be counted in the thresholds
+     */
+    public boolean getCountSkippedTests() {
+        return countSkippedTests;
+    }
 
-	/**
-	 * Gets the comma separated list of other filemasks to copy into build dir
-	 * @return List of files as string
-	 */
-	public String getOtherFiles() {
-		return StringUtils.join(otherFiles, ",");
-	}
+    /**
+     * Gets value of enableCache
+     *
+     * @return true if cache is enabled
+     */
+    public boolean getEnableCache() {
+        return enableCache;
+    }
 
-	/**
-	 * Gets the value of overwriteXAxisLabel
-	 * @return X axis label for the trend
-	 */
-	public String getOverwriteXAxisLabel() {
-		return overwriteXAxisLabel;
-	}
+    /**
+     * Gets the comma separated list of other filemasks to copy into build dir
+     *
+     * @return List of files as string
+     */
+    public String getOtherFiles() {
+        return StringUtils.join(otherFiles, ",");
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public Collection<Action> getProjectActions(AbstractProject<?, ?> project) {
-		Collection<Action> actions = new ArrayList<>();
-		RobotProjectAction roboAction = new RobotProjectAction(project);
-		actions.add(roboAction);
-		return actions;
-	}
+    /**
+     * Gets the value of overwriteXAxisLabel
+     *
+     * @return X axis label for the trend
+     */
+    public String getOverwriteXAxisLabel() {
+        return overwriteXAxisLabel;
+    }
 
-	protected RobotResult parse(String expandedTestResults, String expandedLogFileName, String expandedReportFileName, String outputPath, Run<?,?> build, FilePath workspace,
-			Launcher launcher, TaskListener listener) throws IOException,
-			InterruptedException {
-		return new RobotParser().parse(expandedTestResults, outputPath, build, workspace, expandedLogFileName, expandedReportFileName);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<Action> getProjectActions(AbstractProject<?, ?> project) {
+        Collection<Action> actions = new ArrayList<>();
+        RobotProjectAction roboAction = new RobotProjectAction(project);
+        actions.add(roboAction);
+        return actions;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-        @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION",
-                            justification = "Lower risk to suppress the warning than to stop catching the null pointer exception")
-	public void perform(Run<?, ?> build, @NonNull FilePath workspace, @NonNull EnvVars buildEnv, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
-		if (build.getResult() != Result.ABORTED) {
-			PrintStream logger = listener.getLogger();
-			logger.println(Messages.robot_publisher_started());
-			logger.println(Messages.robot_publisher_only_critical());
-			logger.println(Messages.robot_publisher_parsing());
-			RobotResult result;
+    protected RobotResult parse(String expandedTestResults, String expandedLogFileName, String expandedReportFileName, String outputPath, Run<?, ?> build, FilePath workspace,
+                                Launcher launcher, TaskListener listener) throws IOException,
+            InterruptedException {
+        return new RobotParser().parse(expandedTestResults, outputPath, build, workspace, expandedLogFileName, expandedReportFileName);
+    }
 
-			try {
-				String expandedOutputFileName = buildEnv.expand(getOutputFileName());
-				String expandedOutputPath = buildEnv.expand(getOutputPath());
-				String expandedReportFileName = buildEnv.expand(getReportFileName());
-				String expandedLogFileName = buildEnv.expand(getLogFileName());
-				String logFileJavascripts = trimSuffix(expandedLogFileName) + ".js";
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION",
+            justification = "Lower risk to suppress the warning than to stop catching the null pointer exception")
+    public void perform(Run<?, ?> build, @NonNull FilePath workspace, @NonNull EnvVars buildEnv, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
+        if (build.getResult() != Result.ABORTED) {
+            PrintStream logger = listener.getLogger();
+            logger.println(Messages.robot_publisher_started());
+            logger.println(Messages.robot_publisher_only_critical());
+            logger.println(Messages.robot_publisher_parsing());
+            RobotResult result;
 
-				result = parse(expandedOutputFileName, expandedLogFileName, expandedReportFileName, expandedOutputPath, build, workspace, launcher, listener);
-				logger.println(Messages.robot_publisher_done());
+            try {
+                String expandedOutputFileName = buildEnv.expand(getOutputFileName());
+                String expandedOutputPath = buildEnv.expand(getOutputPath());
+                String expandedReportFileName = buildEnv.expand(getReportFileName());
+                String expandedLogFileName = buildEnv.expand(getLogFileName());
+                String logFileJavascripts = trimSuffix(expandedLogFileName) + ".js";
 
-				// Check if log and report files exist
-				FilePath outputDir = new FilePath(workspace, expandedOutputPath);
-				if (outputDir.list(expandedLogFileName).length == 0) {
-					logger.println(Messages.robot_publisher_file_not_found() + " " + expandedLogFileName);
-				}
-				if (outputDir.list(expandedReportFileName).length == 0) {
-					logger.println(Messages.robot_publisher_file_not_found() + " " + expandedReportFileName);
-				}
+                result = parse(expandedOutputFileName, expandedLogFileName, expandedReportFileName, expandedOutputPath, build, workspace, launcher, listener);
+                logger.println(Messages.robot_publisher_done());
 
-				if (!DEFAULT_JENKINS_ARCHIVE_DIR.equalsIgnoreCase(getArchiveDirName())) {
-					logger.println(Messages.robot_publisher_copying());
-					//Save configured Robot files (including split output) to build dir
-					copyFilesToBuildDir(build, workspace, expandedOutputPath, StringUtils.join(modifyMasksforSplittedOutput(new String[]{expandedReportFileName, expandedLogFileName, logFileJavascripts}), ","));
+                // Check if log and report files exist
+                FilePath outputDir = new FilePath(workspace, expandedOutputPath);
+                if (outputDir.list(expandedLogFileName).length == 0) {
+                    logger.println(Messages.robot_publisher_file_not_found() + " " + expandedLogFileName);
+                }
+                if (outputDir.list(expandedReportFileName).length == 0) {
+                    logger.println(Messages.robot_publisher_file_not_found() + " " + expandedReportFileName);
+                }
 
-					if (!getDisableArchiveOutput()) {
-						copyFilesToBuildDir(build, workspace, expandedOutputPath, StringUtils.join(modifyMasksforSplittedOutput(new String[]{expandedOutputFileName}), ","));
-					}
+                if (!DEFAULT_JENKINS_ARCHIVE_DIR.equalsIgnoreCase(getArchiveDirName())) {
+                    logger.println(Messages.robot_publisher_copying());
+                    //Save configured Robot files (including split output) to build dir
+                    copyFilesToBuildDir(build, workspace, expandedOutputPath, StringUtils.join(modifyMasksforSplittedOutput(new String[]{expandedReportFileName, expandedLogFileName, logFileJavascripts}), ","));
 
-					//Save other configured files to build dir
-					if(StringUtils.isNotBlank(getOtherFiles())) {
-						String filemask = buildEnv.expand(getOtherFiles());
-						copyFilesToBuildDir(build, workspace, expandedOutputPath, filemask);
-					}
-					logger.println(Messages.robot_publisher_done());
-				}
+                    if (!getDisableArchiveOutput()) {
+                        copyFilesToBuildDir(build, workspace, expandedOutputPath, StringUtils.join(modifyMasksforSplittedOutput(new String[]{expandedOutputFileName}), ","));
+                    }
 
-				logger.println(Messages.robot_publisher_assigning());
+                    //Save other configured files to build dir
+                    if (StringUtils.isNotBlank(getOtherFiles())) {
+                        String filemask = buildEnv.expand(getOtherFiles());
+                        copyFilesToBuildDir(build, workspace, expandedOutputPath, filemask);
+                    }
+                    logger.println(Messages.robot_publisher_done());
+                }
 
-				String label = buildEnv.expand(overwriteXAxisLabel);
-				RobotBuildAction action = new RobotBuildAction(build, result, getArchiveDirName(), listener, expandedReportFileName, expandedLogFileName, enableCache, label);
-				build.addAction(action);
+                logger.println(Messages.robot_publisher_assigning());
 
-				// set RobotProjectAction as project action
-				Job<?,?> job = build.getParent();
-				if (job != null) {
-					RobotProjectAction projectAction = new RobotProjectAction(job);
-					try {
-						job.addOrReplaceAction(projectAction);
-					} catch (UnsupportedOperationException | NullPointerException e) {
-						// it is possible that the action collection is an unmodifiable collection
-						// NullPointerException is thrown if a freestyle job runs
-					}
+                String label = buildEnv.expand(overwriteXAxisLabel);
+                RobotBuildAction action = new RobotBuildAction(build, result, getArchiveDirName(), listener, expandedReportFileName, expandedLogFileName, enableCache, label, countSkippedTests);
+                build.addAction(action);
 
-					logger.println(Messages.robot_publisher_done());
-					logger.println(Messages.robot_publisher_checking());
+                // set RobotProjectAction as project action
+                Job<?, ?> job = build.getParent();
+                if (job != null) {
+                    RobotProjectAction projectAction = new RobotProjectAction(job);
+                    try {
+                        job.addOrReplaceAction(projectAction);
+                    } catch (UnsupportedOperationException | NullPointerException e) {
+                        // it is possible that the action collection is an unmodifiable collection
+                        // NullPointerException is thrown if a freestyle job runs
+                    }
 
-					Result buildResult = getBuildResult(build, result);
-					build.setResult(buildResult);
+                    logger.println(Messages.robot_publisher_done());
+                    logger.println(Messages.robot_publisher_checking());
 
-					logger.println(Messages.robot_publisher_done());
-					logger.println(Messages.robot_publisher_finished());
-				}
+                    Result buildResult = getBuildResult(build, result);
+                    build.setResult(buildResult);
 
-			} catch (RuntimeException e) {
-				throw e;
-			} catch (Exception e) {
-				logger.println(Messages.robot_publisher_fail());
-				e.printStackTrace(logger);
-				build.setResult(Result.FAILURE);
-			}
-		}
-	}
+                    logger.println(Messages.robot_publisher_done());
+                    logger.println(Messages.robot_publisher_finished());
+                }
 
-	/**
-	 * Copy files with given filemasks from input path relative to build into specific build file archive dir
-	 * @param build The Jenkins run
-	 * @param inputPath Base path for copy. Relative to build workspace.
-	 * @param filemaskToCopy List of Ant GLOB style filemasks to copy from dirs specified at inputPathMask
-	 * @param workspace Build workspace
-	 * @throws IOException thrown exception
-	 * @throws InterruptedException thrown exception
-	 */
-	public void copyFilesToBuildDir(Run<?, ?> build, FilePath workspace,
-			String inputPath, String filemaskToCopy) throws IOException, InterruptedException {
-		FilePath srcDir = new FilePath(workspace, inputPath);
-		FilePath destDir = new FilePath(new FilePath(build.getRootDir()),
-				getArchiveDirName());
-		srcDir.copyRecursiveTo(filemaskToCopy, destDir);
-	}
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                logger.println(Messages.robot_publisher_fail());
+                e.printStackTrace(logger);
+                build.setResult(Result.FAILURE);
+            }
+        }
+    }
 
-	/**
-	 * Return filename without file suffix.
-	 * @param filename Filename with suffix
-	 * @return filename as string
-	 */
-	public static String trimSuffix(String filename) {
-		int index = filename.lastIndexOf('.');
-		if (index > 0) {
-			filename = filename.substring(0, index);
-		}
-		return filename;
-	}
+    /**
+     * Copy files with given filemasks from input path relative to build into specific build file archive dir
+     *
+     * @param build          The Jenkins run
+     * @param inputPath      Base path for copy. Relative to build workspace.
+     * @param filemaskToCopy List of Ant GLOB style filemasks to copy from dirs specified at inputPathMask
+     * @param workspace      Build workspace
+     * @throws IOException          thrown exception
+     * @throws InterruptedException thrown exception
+     */
+    public void copyFilesToBuildDir(Run<?, ?> build, FilePath workspace,
+                                    String inputPath, String filemaskToCopy) throws IOException, InterruptedException {
+        FilePath srcDir = new FilePath(workspace, inputPath);
+        FilePath destDir = new FilePath(new FilePath(build.getRootDir()),
+                getArchiveDirName());
+        srcDir.copyRecursiveTo(filemaskToCopy, destDir);
+    }
 
-	/**
-	 * Return file suffix from string.
-	 * @param filename Filename with suffix
-	 * @return file suffix as string
-	 */
-	public static String getSuffix(String filename) {
-		int index = filename.lastIndexOf('.');
-		if (index > 0) {
-			return filename.substring(index);
-		}
-		return "";
-	}
+    /**
+     * Return filename without file suffix.
+     *
+     * @param filename Filename with suffix
+     * @return filename as string
+     */
+    public static String trimSuffix(String filename) {
+        int index = filename.lastIndexOf('.');
+        if (index > 0) {
+            filename = filename.substring(0, index);
+        }
+        return filename;
+    }
 
-	/**
-	 * Add wildcard to filemasks between name and file extension in order to copy split output
-	 * e.g. output-001.xml, output-002.xml etc.
-	 * @param filemasks Files to be masked with wildcards
-	 * @return Updated array of filemasks
-	 */
-	private static String[] modifyMasksforSplittedOutput(String[] filemasks){
-		for (int i = 0; i < filemasks.length; i++){
-			filemasks[i] = trimSuffix(filemasks[i]) + "*" + getSuffix(filemasks[i]);
-		}
-		return filemasks;
-	}
+    /**
+     * Return file suffix from string.
+     *
+     * @param filename Filename with suffix
+     * @return file suffix as string
+     */
+    public static String getSuffix(String filename) {
+        int index = filename.lastIndexOf('.');
+        if (index > 0) {
+            return filename.substring(index);
+        }
+        return "";
+    }
 
-	/**
-	 * Determines the build result based on set thresholds. If build is already
-	 * failed before the tests it won't be changed to successful.
-	 *
-	 * @param build
-	 *			Build to be evaluated
-	 * @param result
-	 *			Results associated to build
-	 * @return Result of build
-	 */
-	protected Result getBuildResult(Run<?, ?> build,
-			RobotResult result) {
-		if (build.getResult() != Result.FAILURE) {
-			double passPercentage = result.getPassPercentage(onlyCritical);
-			if (passPercentage < getUnstableThreshold()) {
-				return Result.FAILURE;
-			} else if (passPercentage < getPassThreshold()) {
-				return Result.UNSTABLE;
-			}
-			return Result.SUCCESS;
-		}
-		return Result.FAILURE;
-	}
+    /**
+     * Add wildcard to filemasks between name and file extension in order to copy split output
+     * e.g. output-001.xml, output-002.xml etc.
+     *
+     * @param filemasks Files to be masked with wildcards
+     * @return Updated array of filemasks
+     */
+    private static String[] modifyMasksforSplittedOutput(String[] filemasks) {
+        for (int i = 0; i < filemasks.length; i++) {
+            filemasks[i] = trimSuffix(filemasks[i]) + "*" + getSuffix(filemasks[i]);
+        }
+        return filemasks;
+    }
 
-	/**
-	 * Descriptor for the publisher
-	 */
-	@Extension
-	public static final class DescriptorImpl extends
-			BuildStepDescriptor<Publisher> {
+    /**
+     * Determines the build result based on set thresholds. If build is already
+     * failed before the tests it won't be changed to successful.
+     *
+     * @param build  Build to be evaluated
+     * @param result Results associated to build
+     * @return Result of build
+     */
+    protected Result getBuildResult(Run<?, ?> build,
+                                    RobotResult result) {
+        if (build.getResult() != Result.FAILURE) {
+            double passPercentage = result.getPassPercentage(countSkippedTests);
+            if (passPercentage < getUnstableThreshold()) {
+                return Result.FAILURE;
+            } else if (passPercentage < getPassThreshold()) {
+                return Result.UNSTABLE;
+            }
+            return Result.SUCCESS;
+        }
+        return Result.FAILURE;
+    }
 
-		/**
-		 * {@inheritDoc}
-		 */
-		@SuppressWarnings("rawtypes")
-		@Override
-		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-			return true;
-		}
+    /**
+     * Descriptor for the publisher
+     */
+    @Extension
+    public static final class DescriptorImpl extends
+            BuildStepDescriptor<Publisher> {
 
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public String getDisplayName() {
-			return Messages.robot_description();
-		}
+        /**
+         * {@inheritDoc}
+         */
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
 
-		/**
-		 * Validates the unstable threshold input field.
-		 * @param value Value to be checked for the threshold
-		 * @return OK if value is within threshold
-		 * @throws IOException thrown exception
-		 * @throws ServletException thrown exception
-		 */
-		public FormValidation doCheckUnstableThreshold(
-				@QueryParameter String value) throws IOException,
-				ServletException {
-			if (isPercentageValue(value))
-				return FormValidation.ok();
-			else
-				return FormValidation.error(Messages
-						.robot_config_percentvalidation());
-		}
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.robot_description();
+        }
 
-		/**
-		 * Validates the pass threshold input field.
-		 * @param value Value to be checked for the threshold
-		 * @return OK if value is within threshold
-		 * @throws IOException thrown exception
-		 * @throws ServletException thrown exception
-		 */
-		public FormValidation doCheckPassThreshold(@QueryParameter String value)
-				throws IOException, ServletException {
-			if (isPercentageValue(value))
-				return FormValidation.ok();
-			else
-				return FormValidation.error(Messages
-						.robot_config_percentvalidation());
-		}
+        /**
+         * Validates the unstable threshold input field.
+         *
+         * @param value Value to be checked for the threshold
+         * @return OK if value is within threshold
+         * @throws IOException      thrown exception
+         * @throws ServletException thrown exception
+         */
+        public FormValidation doCheckUnstableThreshold(
+                @QueryParameter String value) throws IOException,
+                ServletException {
+            if (isPercentageValue(value))
+                return FormValidation.ok();
+            else
+                return FormValidation.error(Messages
+                        .robot_config_percentvalidation());
+        }
 
-		private boolean isPercentageValue(String value) {
-			try {
-				double doubleValue = Double.parseDouble(value);
-				if (doubleValue <= 100 && doubleValue >= 0)
-					return true;
-				else
-					return false;
-			} catch (NumberFormatException e) {
-				return false;
-			}
-		}
-	}
+        /**
+         * Validates the pass threshold input field.
+         *
+         * @param value Value to be checked for the threshold
+         * @return OK if value is within threshold
+         * @throws IOException      thrown exception
+         * @throws ServletException thrown exception
+         */
+        public FormValidation doCheckPassThreshold(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (isPercentageValue(value))
+                return FormValidation.ok();
+            else
+                return FormValidation.error(Messages
+                        .robot_config_percentvalidation());
+        }
 
-	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.NONE;
-	}
+        private boolean isPercentageValue(String value) {
+            try {
+                double doubleValue = Double.parseDouble(value);
+                if (doubleValue <= 100 && doubleValue >= 0)
+                    return true;
+                else
+                    return false;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+    }
 
-	public MatrixAggregator createAggregator(MatrixBuild build,
-			Launcher launcher, BuildListener listener) {
-		return new RobotResultAggregator(build, launcher, listener);
-	}
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    public MatrixAggregator createAggregator(MatrixBuild build,
+                                             Launcher launcher, BuildListener listener) {
+        return new RobotResultAggregator(build, launcher, listener);
+    }
 }

--- a/src/main/java/hudson/plugins/robot/RobotStep.java
+++ b/src/main/java/hudson/plugins/robot/RobotStep.java
@@ -38,6 +38,7 @@ public class RobotStep extends Step {
 	private @CheckForNull String[] otherFiles;
 	private boolean enableCache = true;
 	private boolean onlyCritical = true;
+	private boolean countSkippedTests = false;
 	private @CheckForNull String overwriteXAxisLabel;
 
 	
@@ -95,6 +96,8 @@ public class RobotStep extends Step {
 		return this.onlyCritical;
 	}
 
+	public boolean getCountSkippedTests() { return this.countSkippedTests; }
+
 	public String getOverwriteXAxisLabel() {
 		return this.overwriteXAxisLabel;
 	}
@@ -143,7 +146,12 @@ public class RobotStep extends Step {
 	public void setOnlyCritical(boolean onlyCritical) {
 		this.onlyCritical = onlyCritical;
 	}
-	
+
+	@DataBoundSetter
+	public void setCountSkippedTests(boolean countSkippedTests) {
+		this.countSkippedTests = countSkippedTests;
+	}
+
 	@DataBoundSetter
 	public void setOtherFiles(String otherFiles) {
 		otherFiles = Util.fixEmpty(otherFiles);

--- a/src/main/java/hudson/plugins/robot/RobotStepExecution.java
+++ b/src/main/java/hudson/plugins/robot/RobotStepExecution.java
@@ -27,7 +27,7 @@ public class RobotStepExecution extends SynchronousNonBlockingStepExecution<Void
     @Override protected Void run() throws Exception {
     	FilePath workspace = getContext().get(FilePath.class);
         workspace.mkdirs();
-    	RobotPublisher rp = new RobotPublisher(step.getArchiveDirName(), step.getOutputPath(), step.getOutputFileName(), step.getDisableArchiveOutput(), step.getReportFileName(), step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), step.getOnlyCritical(), step.getOtherFiles(), step.getEnableCache(), step.getOverwriteXAxisLabel());
+    	RobotPublisher rp = new RobotPublisher(step.getArchiveDirName(), step.getOutputPath(), step.getOutputFileName(), step.getDisableArchiveOutput(), step.getReportFileName(), step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), step.getOnlyCritical(), step.getCountSkippedTests(), step.getOtherFiles(), step.getEnableCache(), step.getOverwriteXAxisLabel());
     	rp.perform(getContext().get(Run.class), workspace, getContext().get(EnvVars.class), getContext().get(Launcher.class), getContext().get(TaskListener.class));
     	return null;
     }

--- a/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
@@ -312,15 +312,15 @@ public class RobotCaseResult extends RobotTestObject{
 		return 0;
 	}
 
+	@Deprecated
 	@Override
 	public long getCriticalFailed() {
-		if((!isPassed() && !isSkipped()) && isCritical()) return 1;
-		return 0;
+		return this.getFailed();
 	}
 
+	@Deprecated
 	@Override
 	public long getCriticalPassed() {
-		if(isPassed() && isCritical()) return 1;
-		return 0;
+		return this.getPassed();
 	}
 }

--- a/src/main/java/hudson/plugins/robot/model/RobotResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotResult.java
@@ -187,19 +187,15 @@ public class RobotResult extends RobotTestObject {
 
 	/**
 	 * Returns pass percentage of passed tests per total tests.
-	 * @param onlyCritical true if only critical tests are to be calculated
+	 * @param countSkipped true if skipped tests should be included in calculating total tests
 	 * @return Percentage value rounded to 1 decimal
 	 */
-	public double getPassPercentage(boolean onlyCritical) {
+	public double getPassPercentage(boolean countSkipped) {
 		long passed, total;
-		if(onlyCritical) {
-			passed = getCriticalPassed();
-			total = getCriticalTotal();
-		} else {
-			passed = getOverallPassed();
-			// Skipped tests don't count towards pass percentage
-			total = getOverallTotal() - getOverallSkipped();
-		}
+		passed = getOverallPassed();
+		total = getOverallTotal();
+		if (!countSkipped)
+			total -= getOverallSkipped();
 
 		if(total == 0) return 100;
 

--- a/src/main/java/hudson/plugins/robot/model/RobotResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotResult.java
@@ -86,33 +86,30 @@ public class RobotResult extends RobotTestObject {
 	 * Get number of passed critical tests.
 	 * @return number of passed critical tests
 	 */
+	@Deprecated
 	@Exported
 	public long getCriticalPassed(){
-		if(overallStats == null) return criticalPassed;
-		if(overallStats.isEmpty()) return 0;
-		return overallStats.get(0).getPass();
+		return this.getOverallPassed();
 	}
 
 	/**
 	 * Get number of failed critical tests.
 	 * @return number of failed critical tests
 	 */
+	@Deprecated
 	@Exported
 	public long getCriticalFailed(){
-		if(overallStats == null) return criticalFailed;
-		if( overallStats.isEmpty()) return 0;
-		return overallStats.get(0).getFail();
+		return this.getOverallFailed();
 	}
 
 	/**
 	 * Get total number of critical tests.
 	 * @return total number of critical tests
 	 */
+	@Deprecated
 	@Exported
 	public long getCriticalTotal(){
-		if(overallStats == null) return criticalFailed + criticalPassed;
-		if(overallStats.isEmpty()) return 0;
-		return overallStats.get(0).getTotal();
+		return this.getOverallTotal();
 	}
 
 	/**
@@ -424,8 +421,8 @@ public class RobotResult extends RobotTestObject {
 			failed += suite.getFailed();
 			passed += suite.getPassed();
 			skipped += suite.getSkipped();
-			criticalFailed += suite.getCriticalFailed();
-			criticalPassed += suite.getCriticalPassed();
+			criticalFailed += suite.getFailed();
+			criticalPassed += suite.getPassed();
 			duration += suite.getDuration();
 			newMap.put(suite.getDuplicateSafeName(), suite);
 		}

--- a/src/main/java/hudson/plugins/robot/model/RobotSuiteResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotSuiteResult.java
@@ -162,24 +162,27 @@ public class RobotSuiteResult extends RobotTestObject {
 	 * Get number of passed critical tests
 	 * @return number of passed critical tests
 	 */
+	@Deprecated
 	public long getCriticalPassed() {
-		return criticalPassed;
+		return this.getPassed();
 	}
 
 	/**
 	 * Get number of failed critical tests
 	 * @return number of failed critical tests
 	 */
+	@Deprecated
 	public long getCriticalFailed() {
-		return criticalFailed;
+		return this.getFailed();
 	}
 
 	/**
 	 * Get number of all critical tests
 	 * @return number of all critical tests
 	 */
+	@Deprecated
 	public int getCriticalTotal() {
-		return criticalPassed + criticalFailed;
+		return this.getTotal();
 	}
 
 	public void setSchemaVersion(int version) {
@@ -424,8 +427,8 @@ public class RobotSuiteResult extends RobotTestObject {
 			failed += suite.getFailed();
 			passed += suite.getPassed();
 			skipped += suite.getSkipped();
-			criticalFailed += suite.getCriticalFailed();
-			criticalPassed += suite.getCriticalPassed();
+			criticalFailed += suite.getFailed();
+			criticalPassed += suite.getPassed();
 			duration += suite.getDuration();
 			newSuites.put(suite.getDuplicateSafeName(), suite);
 		}

--- a/src/main/java/hudson/plugins/robot/tokens/RobotFailTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotFailTokenMacro.java
@@ -31,10 +31,7 @@ public class RobotFailTokenMacro extends DataBoundTokenMacro {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
-			if(onlyCritical)
-				return Long.toString(result.getCriticalFailed());
-			else
-				return Long.toString(result.getOverallFailed());
+			return Long.toString(result.getOverallFailed());
 		}
 		return "";
 	}

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacro.java
@@ -16,11 +16,8 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 @Extension(optional = true)
 public class RobotPassPercentageTokenMacro extends DataBoundTokenMacro {
 
-	/**
-	 * If true return only pass percentage of critical tests
-	 */
 	@Parameter
-	public boolean onlyCritical;
+	public boolean countSkippedTests;
 	
 	@Override
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
@@ -37,7 +34,7 @@ public class RobotPassPercentageTokenMacro extends DataBoundTokenMacro {
 
 		if (action!=null){
 			RobotResult result = action.getResult();
-			return String.valueOf(result.getPassPercentage(onlyCritical));
+			return String.valueOf(result.getPassPercentage(countSkippedTests));
 		}
 		return "";
 	}

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
@@ -33,10 +33,7 @@ public class RobotPassRatioTokenMacro extends DataBoundTokenMacro {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
-			if(onlyCritical)
-				return result.getCriticalPassed() + " / " + result.getCriticalTotal();
-			else
-				return result.getOverallPassed() + " / " + result.getOverallTotal();
+			return result.getOverallPassed() + " / " + result.getOverallTotal();
 		}
 		return "";
 	}

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassTokenMacro.java
@@ -32,10 +32,7 @@ public class RobotPassTokenMacro extends DataBoundTokenMacro {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
-			if(onlyCritical)
-				return Long.toString(result.getCriticalPassed());
-			else
-				return Long.toString(result.getOverallPassed());
+			return Long.toString(result.getOverallPassed());
 		}
 		return "";
 	}

--- a/src/main/java/hudson/plugins/robot/tokens/RobotTotalTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotTotalTokenMacro.java
@@ -32,10 +32,7 @@ public class RobotTotalTokenMacro extends DataBoundTokenMacro {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
-			if(onlyCritical)
-				return Long.toString(result.getCriticalTotal());
-			else
-				return Long.toString(result.getOverallTotal());
+			return Long.toString(result.getOverallTotal());
 		}
 		return "";
 	}

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
@@ -54,7 +54,10 @@ limitations under the License.
            <f:textbox />
     </f:entry>
     <f:entry field="onlyCritical">
-        <f:checkbox default="true"/>${%thresholds.onlycritical}
+        <f:checkbox default="true"/>${%thresholds.onlyCritical}
+    </f:entry>
+    <f:entry field="countSkippedTests">
+        <f:checkbox default="false"/>${%thresholds.countSkippedTests}
     </f:entry>
     </table>
   </f:entry>

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
@@ -21,4 +21,5 @@ advanced.overwriteXAxisLabel.description=Overwrite default x-axis label for publ
 
 
 thresholds.label=Thresholds for build result
-thresholds.onlycritical=Use thresholds for critical tests only
+thresholds.onlyCritical=DEPRECATED! THIS FLAG DOES NOTHING! - Use thresholds for critical tests only
+thresholds.countSkippedTests=Include tests with "skip" status in total tests count for thresholds

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
@@ -54,7 +54,10 @@ limitations under the License.
            <f:textbox />
     </f:entry>
     <f:entry field="onlyCritical">
-        <f:checkbox default="true"/>${%thresholds.onlycritical}
+        <f:checkbox default="true"/>${%thresholds.onlyCritical}
+    </f:entry>
+    <f:entry field="countSkippedTests">
+        <f:checkbox default="false"/>${%thresholds.countSkippedTests}
     </f:entry>
     </table>
   </f:entry>

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
@@ -20,4 +20,5 @@ advanced.overwriteXAxisLabel=X-axis label
 advanced.overwriteXAxisLabel.description=Overwrite default x-axis label for publish trend
 
 thresholds.label=Thresholds for build result
-thresholds.onlycritical=Use thresholds for critical tests only
+thresholds.onlyCritical=DEPRECATED! THIS FLAG DOES NOTHING! - Use thresholds for critical tests only
+thresholds.countSkippedTests=Include tests with "skip" status in total tests count for thresholds

--- a/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
+++ b/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>	
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Copyright 2008-2014 Nokia Solutions and Networks Oy
 
@@ -15,66 +15,83 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:u="/util">
-  <st:attribute name="action" use="required"/>
-  <style type="text/css">
-  #robot-summary-table {
-    text-align: center;
-    border-collapse: collapse;
-  }
-  #robot-summary-table th {
-      font-weight: normal;
-      padding: 3px;
-  }
-  #robot-summary-table td {
-      font-weight: bold;
-      border-left: 1px solid #888;
-      margin: 0px;
-      padding: 3px;
-  }
-  #robot-summary-table .table-upper-row {
-      border-bottom: 1px solid #888;
-  }
-  #robot-summary-table .fail {
-      color: #f00;
-  }
-  #robot-summary-table .pass {
-      color: #0f0;
-  }
-  </style>
-  <table class="table" id="robot-summary-table">
-    <tr>
-      <th></th>
-      <th>Total</th>
-      <th>Failed</th>
-      <th>Passed</th>
-      <th>Skipped</th>
-      <th>Pass %</th>
-    </tr>
-    <tr>
-      <th>All tests</th>
-      <td style="border-left:0px;">${attrs.action.result.overallTotal}</td>
-      <td>
-        <j:set var="totalFails" value="pass" />
-        <j:if test="${attrs.action.result.overallFailed > 0}">
-           <j:set var="totalFails" value="fail" />
-        </j:if>
-        <span class="${totalFails}">${attrs.action.result.overallFailed}</span>
-      </td>
-      <td>${attrs.action.result.overallPassed}</td>
-      <td>${attrs.action.result.overallSkipped}</td>
-      <td>${attrs.action.overallPassPercentage}</td>
-    </tr>
-  </table>
-  <p>
-  <ul>
-  <li><a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}">Browse results</a></li>
-  <j:if test="${attrs.action.logFileLink != null}">
-    <li><a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}/report/${attrs.action.logFileLink}">Open ${attrs.action.logFileLink}</a></li>
-  </j:if>
-  <j:if test="${attrs.action.logHtmlLink != null}">
-    <li><a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}/report/${attrs.action.logHtmlLink}">Open ${attrs.action.logHtmlLink}</a></li>
-  </j:if>
-  </ul>
-  </p>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:u="/util">
+    <st:attribute name="action" use="required"/>
+    <style type="text/css">
+        #robot-summary-table {
+        text-align: center;
+        border-collapse: collapse;
+        }
+        #robot-summary-table th {
+        font-weight: normal;
+        padding: 3px;
+        }
+        #robot-summary-table td {
+        font-weight: bold;
+        border-left: 1px solid #888;
+        margin: 0px;
+        padding: 3px;
+        }
+        #robot-summary-table .table-upper-row {
+        border-bottom: 1px solid #888;
+        }
+        #robot-summary-table .fail {
+        color: #f00;
+        }
+        #robot-summary-table .pass {
+        color: #0f0;
+        }
+    </style>
+    <table class="table" id="robot-summary-table">
+        <tr>
+            <th></th>
+            <th>Total</th>
+            <th>Failed</th>
+            <th>Passed</th>
+            <th>Skipped</th>
+            <th>Pass %</th>
+        </tr>
+        <tr>
+            <th>All tests</th>
+            <td style="border-left:0px;">${attrs.action.result.overallTotal}</td>
+            <td>
+                <j:set var="totalFails" value="pass"/>
+                <j:if test="${attrs.action.result.overallFailed > 0}">
+                    <j:set var="totalFails" value="fail"/>
+                </j:if>
+                <span class="${totalFails}">${attrs.action.result.overallFailed}</span>
+            </td>
+            <td>${attrs.action.result.overallPassed}</td>
+            <td>${attrs.action.result.overallSkipped}</td>
+            <td>
+                <j:set var="totalPassPercentage" value="${attrs.action.overallPassPercentage}"/>
+                <j:if test="${attrs.action.countSkippedTests}">
+                    <j:set var="totalPassPercentage" value="${attrs.action.criticalPassPercentage}"/>
+                </j:if>
+                ${totalPassPercentage}
+            </td>
+        </tr>
+    </table>
+    <p>
+        <ul>
+            <li>
+                <a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}">Browse results</a>
+            </li>
+            <j:if test="${attrs.action.logFileLink != null}">
+                <li>
+                    <a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}/report/${attrs.action.logFileLink}">
+                        Open ${attrs.action.logFileLink}
+                    </a>
+                </li>
+            </j:if>
+            <j:if test="${attrs.action.logHtmlLink != null}">
+                <li>
+                    <a href="${rootURL}/${attrs.action.owner.url}${attrs.action.urlName}/report/${attrs.action.logHtmlLink}">
+                        Open ${attrs.action.logHtmlLink}
+                    </a>
+                </li>
+            </j:if>
+        </ul>
+    </p>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
+++ b/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
@@ -52,20 +52,6 @@ limitations under the License.
       <th>Pass %</th>
     </tr>
     <tr>
-      <th>Critical tests</th>
-      <td class="table-upper-row" style="border-left:0px;">${attrs.action.result.criticalTotal}</td>
-      <td class="table-upper-row">
-        <j:set var="criticalFails" value="pass" />
-        <j:if test="${attrs.action.result.criticalFailed > 0}">
-           <j:set var="criticalFails" value="fail" />
-        </j:if>
-        <span class="${criticalFails}">${attrs.action.result.criticalFailed}</span>
-      </td>
-      <td class="table-upper-row">${attrs.action.result.criticalPassed}</td>
-      <td class="table-upper-row">0</td>
-      <td class="table-upper-row">${attrs.action.criticalPassPercentage}</td>
-    </tr>
-    <tr>
       <th>All tests</th>
       <td style="border-left:0px;">${attrs.action.result.overallTotal}</td>
       <td>

--- a/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotProjectActionTest.java
@@ -59,7 +59,7 @@ public class RobotProjectActionTest extends TestCase {
 		when(build.getProject()).thenReturn(p);
 		when(build.getRootDir()).thenReturn(tmpDir);
 		RobotResult result = mock(RobotResult.class);
-		RobotBuildAction buildAction = new RobotBuildAction(build, result, "", null, null, null, false, "");
+		RobotBuildAction buildAction = new RobotBuildAction(build, result, "", null, null, null, false, "", false);
 		when(build.getAction(RobotBuildAction.class)).thenReturn(buildAction);
 		when(p.getLastBuild()).thenReturn(build);
 
@@ -75,7 +75,7 @@ public class RobotProjectActionTest extends TestCase {
 		when(buildWithAction.getProject()).thenReturn(p);
 		when(buildWithAction.getRootDir()).thenReturn(tmpDir);
 		RobotResult result = mock(RobotResult.class);
-		RobotBuildAction buildAction = new RobotBuildAction(buildWithAction, result, "", null, null, null, false, "");
+		RobotBuildAction buildAction = new RobotBuildAction(buildWithAction, result, "", null, null, null, false, "", false);
 		when(buildWithAction.getAction(RobotBuildAction.class)).thenReturn(buildAction);
 
 		when(p.getLastBuild()).thenReturn(lastBuild);

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -56,20 +56,20 @@ public class RobotPublisherSystemTest {
 	@Test
 	public void testRoundTripConfig() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testRoundTripConfig");
-		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
+		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, false,"dir1/*.jpg, dir2/*.png",
 				false, "");
 		p.getPublishersList().add(before);
 		j.configRoundtrip(p);
 		RobotPublisher after = p.getPublishersList().get(RobotPublisher.class);
 		assertThat(
-				"outputPath,outputFileName,reportFileName,logFileName,passThreshold,unstableThreshold,onlyCritical,otherFiles",
+				"outputPath,outputFileName,reportFileName,logFileName,passThreshold,unstableThreshold,onlyCritical,countSkippedTests,otherFiles",
 				before, samePropertyValuesAs(after));
 	}
 
 	@Test
 	public void testConfigView() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testConfigView");
-		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
+		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, false,"dir1/*.jpg, dir2/*.png",
 				false, "");
 		p.getPublishersList().add(before);
 		HtmlPage page = j.createWebClient().getPage(p, "configure");
@@ -86,8 +86,8 @@ public class RobotPublisherSystemTest {
 		WebAssert.assertInputContainsValue(page, "_.unstableThreshold", "27.0");
 		WebAssert.assertInputPresent(page, "_.passThreshold");
 		WebAssert.assertInputContainsValue(page, "_.passThreshold", "11.0");
-		WebAssert.assertInputPresent(page, "_.onlyCritical");
-		WebAssert.assertInputContainsValue(page, "_.onlyCritical", "on");
+		WebAssert.assertInputPresent(page, "_.countSkippedTests");
+		WebAssert.assertInputContainsValue(page, "_.countSkippedTests", "on");
 		WebAssert.assertInputPresent(page, "_.otherFiles");
 		WebAssert.assertInputContainsValue(page, "_.otherFiles", "dir1/*.jpg,dir2/*.png");
 	}

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -475,12 +475,7 @@ public class RobotPublisherSystemTest {
 	private void verifyTotalsTable(HtmlPage page, int totalTests, int totalFailed, int totalSkipped, String totalPercents,
 			int totalCritical, int criticalFailed, String criticalPercents) {
 		HtmlTable table = page.getHtmlElementById("robot-summary-table");
-		String expectedTable = "<tableclass=\"table\"id=\"robot-summary-table\"><tbody><tr><th/><th>Total</th><th>Failed</th><th>Passed</th><th>Skipped</th><th>Pass%</th></tr><tr><th>Criticaltests</th>"
-				+ "<tdclass=\"table-upper-row\"style=\"border-left:0px;\">" + totalCritical + "</td>"
-				+ "<tdclass=\"table-upper-row\"><spanclass=\"" + (criticalFailed == 0 ? "pass" : "fail") + "\">" + criticalFailed + "</span></td>"
-				+ "<tdclass=\"table-upper-row\">" + (totalCritical - totalFailed) + "</td>"
-				+ "<tdclass=\"table-upper-row\">0</td>"
-				+ "<tdclass=\"table-upper-row\">" + criticalPercents + "</td></tr>"
+		String expectedTable = "<tableclass=\"table\"id=\"robot-summary-table\"><tbody><tr><th/><th>Total</th><th>Failed</th><th>Passed</th><th>Skipped</th><th>Pass%</th></tr>"
 				+ "<tr><th>Alltests</th><tdstyle=\"border-left:0px;\">" + totalTests + "</td>"
 				+ "<td><spanclass=\"" + (totalFailed == 0 ? "pass" : "fail") + "\">" + totalFailed + "</span></td>"
 				+ "<td>" + (totalTests - totalFailed) + "</td>"

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -142,5 +142,5 @@ public class RobotPublisherTest {
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("xxe_output.xml", null, null);
 		RobotResult result = remoteOperation.invoke(new File(RobotPublisherTest.class.getResource("xxe_output.xml").toURI()).getParentFile(), null);
 	}
-	
+
 }

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -32,13 +32,14 @@ import org.junit.Test;
 
 public class RobotPublisherTest {
 	private final boolean onlyCritical = false;
+	private final boolean countSkipped = false;
 
 	@Before
 	public void setUp() throws Exception {
 	}
 
 	private RobotPublisher getRobotPublisher(double passThreshold, double unstableThreshold) {
-		return new RobotPublisher(null, "", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, "", false, "");
+		return new RobotPublisher(null, "", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, countSkipped, "", false, "");
 	}
 
 	@Test

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import hudson.plugins.robot.RobotParserTest;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -92,8 +93,9 @@ public class RobotResultTest {
 		assertNotNull(result.getSuite("Somecases_1"));
 	}
 
+	@Deprecated
 	@Test
-	//TODO; should add tests for all parsed fields? Refactor name to parsertest
+	@Ignore
 	public void testShouldParseCriticalCases(){
 		assertEquals(19, result.getCriticalTotal());
 	}
@@ -107,7 +109,9 @@ public class RobotResultTest {
 		assertEquals("Test failed miserably!", errorMsg.trim());
 	}
 
+	@Deprecated
 	@Test
+	@Ignore
 	public void testShouldParseNewCriticalCases() throws Exception{
 
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
@@ -127,12 +131,16 @@ public class RobotResultTest {
 		assertEquals(10, result.getOverallFailed());
 	}
 
+	@Deprecated
 	@Test
+	@Ignore
 	public void testShouldParseFailedCriticalCases(){
 		assertEquals(9, result.getCriticalFailed());
 	}
 
+	@Deprecated
 	@Test
+	@Ignore
 	public void testShouldParseFailedNewCriticalCases() throws Exception{
 		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
 		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -369,4 +369,22 @@ public class RobotResultTest {
 		assertEquals(0.001748, caseResult.getElapsedtime(), 0.01);
 		assertNull(caseResult.getEndtime());
 	}
+
+	@Test
+	public void testGetPassPercentageWithoutSkippedTests() throws Exception {
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("robot4_skip.xml", null, null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("robot4_skip.xml").toURI()).getParentFile(), null);
+		result.tally(null);
+
+		assertEquals(66.6, result.getPassPercentage(false), 0);
+	}
+
+	@Test
+	public void testGetPassPercentageWithSkippedTests() throws Exception {
+		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("robot4_skip.xml", null, null);
+		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("robot4_skip.xml").toURI()).getParentFile(), null);
+		result.tally(null);
+
+		assertEquals(33.3, result.getPassPercentage(true), 0);
+	}
 }

--- a/src/test/java/hudson/plugins/robot/tokens/RobotFailTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotFailTokenMacroTest.java
@@ -26,7 +26,6 @@ public class RobotFailTokenMacroTest extends TestCase {
 		RobotResult result = Mockito.mock(RobotResult.class);
 		
 		Mockito.when(result.getOverallFailed()).thenReturn(6l);
-		Mockito.when(result.getCriticalFailed()).thenReturn(5l);
 		Mockito.when(action.getResult()).thenReturn(result);
 		Mockito.when(build.getAction(RobotBuildAction.class)).thenReturn(action);
 	}
@@ -37,7 +36,7 @@ public class RobotFailTokenMacroTest extends TestCase {
 	
 	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
 		token.onlyCritical = true;
-		assertEquals("5",token.evaluate(build, listener, macroName));
+		assertEquals("6",token.evaluate(build, listener, macroName));
 	}
 	
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{

--- a/src/test/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacroTest.java
@@ -40,12 +40,12 @@ public class RobotPassPercentageTokenMacroTest extends TestCase {
 	}
 	
 	public void testTokenConversionWithOnlyCritical() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = true;
+		token.countSkippedTests = true;
 		assertEquals("55.0",token.evaluate(build, listener, macroName));
 	}
 	
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = false;
+		token.countSkippedTests = false;
 		assertEquals("41.0",token.evaluate(build, listener, macroName));
 	}
 }

--- a/src/test/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacroTest.java
@@ -29,8 +29,6 @@ public class RobotPassRatioTokenMacroTest extends TestCase {
 		
 		Mockito.when(result.getOverallPassed()).thenReturn(6l);
 		Mockito.when(result.getOverallTotal()).thenReturn(13l);
-		Mockito.when(result.getCriticalPassed()).thenReturn(6l);
-		Mockito.when(result.getCriticalTotal()).thenReturn(13l);
 		Mockito.when(action.getResult()).thenReturn(result);
 		Mockito.when(build.getAction(RobotBuildAction.class)).thenReturn(action);
 	}

--- a/src/test/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacroTest.java
@@ -29,8 +29,8 @@ public class RobotPassRatioTokenMacroTest extends TestCase {
 		
 		Mockito.when(result.getOverallPassed()).thenReturn(6l);
 		Mockito.when(result.getOverallTotal()).thenReturn(13l);
-		Mockito.when(result.getCriticalPassed()).thenReturn(5l);
-		Mockito.when(result.getCriticalTotal()).thenReturn(5l);
+		Mockito.when(result.getCriticalPassed()).thenReturn(6l);
+		Mockito.when(result.getCriticalTotal()).thenReturn(13l);
 		Mockito.when(action.getResult()).thenReturn(result);
 		Mockito.when(build.getAction(RobotBuildAction.class)).thenReturn(action);
 	}
@@ -41,7 +41,7 @@ public class RobotPassRatioTokenMacroTest extends TestCase {
 	
 	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
 		token.onlyCritical = true;
-		assertEquals("5 / 5",token.evaluate(build, listener, macroName));
+		assertEquals("6 / 13",token.evaluate(build, listener, macroName));
 	}
 	
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{

--- a/src/test/java/hudson/plugins/robot/tokens/RobotPassTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotPassTokenMacroTest.java
@@ -26,7 +26,6 @@ public class RobotPassTokenMacroTest extends TestCase {
 		RobotResult result = Mockito.mock(RobotResult.class);
 		
 		Mockito.when(result.getOverallPassed()).thenReturn(6l);
-		Mockito.when(result.getCriticalPassed()).thenReturn(5l);
 		Mockito.when(action.getResult()).thenReturn(result);
 		Mockito.when(build.getAction(RobotBuildAction.class)).thenReturn(action);
 	}
@@ -34,10 +33,10 @@ public class RobotPassTokenMacroTest extends TestCase {
 	public void testAcceptsName(){
 		assertTrue(token.acceptsMacroName(macroName));
 	}
-	
+
 	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
 		token.onlyCritical = true;
-		assertEquals("5",token.evaluate(build, listener, macroName));
+		assertEquals("6",token.evaluate(build, listener, macroName));
 	}
 	
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{

--- a/src/test/java/hudson/plugins/robot/tokens/RobotTotalTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotTotalTokenMacroTest.java
@@ -26,7 +26,6 @@ public class RobotTotalTokenMacroTest extends TestCase {
 		RobotResult result = Mockito.mock(RobotResult.class);
 		
 		Mockito.when(result.getOverallTotal()).thenReturn(6l);
-		Mockito.when(result.getCriticalTotal()).thenReturn(5l);
 		Mockito.when(action.getResult()).thenReturn(result);
 		Mockito.when(build.getAction(RobotBuildAction.class)).thenReturn(action);
 	}
@@ -37,7 +36,7 @@ public class RobotTotalTokenMacroTest extends TestCase {
 	
 	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
 		token.onlyCritical = true;
-		assertEquals("5",token.evaluate(build, listener, macroName));
+		assertEquals("6",token.evaluate(build, listener, macroName));
 	}
 	
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{


### PR DESCRIPTION
* Further deprecate the use of `onlyCritical` flag. It no longer does anything, but is still kept to keep existing pipelines alive.
* Deprecate `getCriticalPassed` and `getCriticalFailed` functions. They will now just return overall passed/failed test cases.
* Introduce a new flag `countSkippedTests` that either ignores skipped tests when calculating pass percentage (current behaviour) or takes them into account (new behaviour)
* Deprecate several unit tests as they are testing test criticality parsing, which is no longer done.