### PR TITLE
JENKINS-69668- Add possibility to add error messages to failed token macro

### DIFF
--- a/src/main/java/hudson/plugins/robot/tokens/RobotFailedCasesTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotFailedCasesTokenMacro.java
@@ -17,6 +17,9 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 @Extension(optional = true)
 public class RobotFailedCasesTokenMacro extends DataBoundTokenMacro {
 
+	@Parameter
+	public boolean addErrorMessages;
+
 	@Override
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,
@@ -35,6 +38,9 @@ public class RobotFailedCasesTokenMacro extends DataBoundTokenMacro {
 			String newline = "";
 			for (RobotCaseResult failedCase : result.getAllFailedCases()){
 				builder.append(newline).append(failedCase.getRelativePackageName(result));
+				if (addErrorMessages && failedCase.getErrorMsg() != null && !failedCase.getErrorMsg().isEmpty()) {
+					builder.append(": ").append(failedCase.getErrorMsg());
+				}
 				newline = "\n";
 			}
 

--- a/src/test/java/hudson/plugins/robot/tokens/RobotFailedCasesTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotFailedCasesTokenMacroTest.java
@@ -36,10 +36,12 @@ public class RobotFailedCasesTokenMacroTest extends TestCase {
 		
 		RobotCaseResult case1 = Mockito.mock(RobotCaseResult.class);
 		Mockito.when(case1.getRelativePackageName(result)).thenReturn("Failcases.subcases.Failure1");
-		
+		Mockito.when(case1.getErrorMsg()).thenReturn("Case1 failed");
+
 		RobotCaseResult case2 = Mockito.mock(RobotCaseResult.class);
 		Mockito.when(case2.getRelativePackageName(result)).thenReturn("Morefails.Failure2");
-		
+		Mockito.when(case2.getErrorMsg()).thenReturn("Case2 failed");
+
 		failedList.add(case1);
 		failedList.add(case2);
 		
@@ -52,7 +54,12 @@ public class RobotFailedCasesTokenMacroTest extends TestCase {
 		assertTrue(new RobotFailedCasesTokenMacro().acceptsMacroName(macroName));
 	}
 	
-	public void testTokenConversion() throws MacroEvaluationException, IOException, InterruptedException{
+	public void testTokenConversionWithoutMessages() throws MacroEvaluationException, IOException, InterruptedException{
 		assertEquals("Failcases.subcases.Failure1\nMorefails.Failure2",token.evaluate(build, listener, macroName));
+	}
+
+	public void testTokenConversionWithMessages() throws MacroEvaluationException, IOException, InterruptedException{
+		token.addErrorMessages = true;
+		assertEquals("Failcases.subcases.Failure1: Case1 failed\nMorefails.Failure2: Case2 failed",token.evaluate(build, listener, macroName));
 	}
 }


### PR DESCRIPTION
Optional parameter to add error messages into the failed case token macro

❗ #78 needs to merged first, so that documentation for the token macro can be updated as well.