### PR TITLE
improve link target on dashboard to a better results overview

### DIFF
--- a/src/main/java/hudson/plugins/robot/view/RobotListViewColumn.java
+++ b/src/main/java/hudson/plugins/robot/view/RobotListViewColumn.java
@@ -60,7 +60,7 @@ public class RobotListViewColumn extends ListViewColumn {
 	}
 
 	public String getLogUrl(Item job) {
-		return getRobotPath(job)+"report/log.html";
+		return getRobotPath(job)+"report/report.html#totals";
 	}
 
 	public String getTrendUrl(Item job) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This pull request improves the link target on the Jenkins Robot Plugin dashboard to provide a better overview of the results. The link has been updated from `report/log.html` to `report/report.html#totals`, which directs users to a more relevant section of the report.

### Testing done
I manually tested the change by navigating to the dashboard and clicking the updated link. The link now correctly redirects to the totals section of the report, providing a clearer overview of the results. I verified that the previous link (`report/log.html`) was replaced and that the new link functions as intended.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
