### PR TITLE
Drop support for test criticality

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -176,7 +176,9 @@ security vulnerabilities**.
 A new flag `countSkippedTests` has been added to the pipeline step to allow users to choose whether to count skipped
 tests in the pass percentage calculation.
 
-The plugin still supports RF 3.x, but no longer takes criticality into account. If you want to use RF 3.x with criticality, please downgrade to the last major version (4.0.0)
+## Robot Framework <3.0 compatibility
+
+If you want to use RF 3.x with criticality, please downgrade to the major version 4.0.0. Plugin versions 5.x support RF 3.x as well, but no longer takes criticality into account.
 
 ## Overall Screenshots
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -140,8 +140,9 @@ Prerequisites: token-macro plugin and email-ext plugin installed.
     -   `${ROBOT_PASSPERCENTAGE, countSkippedTests}` - Expands to pass percentage
         of tests. (passed / total \* 100 %).
         `countSkippedTests` is an optional parameter that can be used to include skipped tests in the total count. Default value is `false`.
-    -   `${ROBOT_PASSRATIO}` - Expands to build result in 'passed
-        / total' format. This total includes skipped test cases.
+    -   `${ROBOT_PASSRATIO, countSkippedTests}` - Expands to build result in 'passed
+        / total' format.
+        `countSkippedTests` is an optional parameter that can be used to include skipped tests in the total count. Default value is `True`.
     -   `${ROBOT_PASSED}` - Expands to count of passed cases.
     -   `${ROBOT_REPORTLINK}` - If logfile link is configured in the Robot
         plugin this link will point to that file for the build. Else show

--- a/doc/README.md
+++ b/doc/README.md
@@ -64,8 +64,8 @@ Tracker](https://issues.jenkins-ci.org/issues/?jql=project+%3D+JENKINS+AND+compo
     persist for viewing later in the logs you must configure them under
     "Advanced... -\> Other files to copy". The field accepts comma
     separated list of files and supports wildcards `*` and `?`.
-9.  Set thresholds and optionally disable thresholds for critical tests
-    only to count every test in the pass percentage.
+9.  Set thresholds and optionally include thresholds for skipped tests
+    to count every test in the pass percentage.
 
 ### Pipeline configuration
 
@@ -85,8 +85,6 @@ Tracker](https://issues.jenkins-ci.org/issues/?jql=project+%3D+JENKINS+AND+compo
         otherFiles: 'screenshot-*.png'
    )
     ```
-
-**NOTE!** `onlyCritical` parameter has been deprecated and will be removed in the future. It has no effect on the results.
 
 ### Configuring direct links to log files
 
@@ -174,8 +172,6 @@ security vulnerabilities**.
 
 ## Robot Framework 4.x+ compatibility
 
-:heavy_exclamation_mark: As we're preparing to drop support for RF 3.x, the `onlyCritical` flag has been deprecated and no
-longer has any effect. It will be removed in the future, but for now it's available for the transition period.
 A new flag `countSkippedTests` has been added to the pipeline step to allow users to choose whether to count skipped
 tests in the pass percentage calculation.
 

--- a/src/main/java/hudson/plugins/robot/AggregatedRobotAction.java
+++ b/src/main/java/hudson/plugins/robot/AggregatedRobotAction.java
@@ -61,10 +61,6 @@ public class AggregatedRobotAction implements Action {
 		return aggregatedResult.getPassPercentage(false);
 	}
 
-	public double getCriticalPassPercentage() {
-		return aggregatedResult.getPassPercentage(true);
-	}
-
 	public String getIconFileName() {
 		return "/plugin/robot/robot.png";
 	}
@@ -100,7 +96,6 @@ public class AggregatedRobotAction implements Action {
 				Boolean.parseBoolean(req.getParameter("zoomSignificant")),
 				false, Boolean.parseBoolean(req.getParameter("hd")),
 				Boolean.parseBoolean(req.getParameter("failedOnly")),
-				Boolean.parseBoolean(req.getParameter("criticalOnly")),
 				labelFormat,
 				Integer.parseInt(req.getParameter("maxBuildsToShow")));
 		g.doPng(req, rsp);
@@ -121,24 +116,6 @@ public class AggregatedRobotAction implements Action {
 			failed += result.getOverallFailed();
 			passed += result.getOverallPassed();
 			skipped += result.getOverallSkipped();
-		}
-
-		@Deprecated
-		@Override
-		public long getCriticalPassed() {
-			return this.getOverallPassed();
-		}
-
-		@Deprecated
-		@Override
-		public long getCriticalFailed() {
-			return this.getOverallFailed();
-		}
-
-		@Deprecated
-		@Override
-		public long getCriticalTotal() {
-			return this.getOverallTotal();
 		}
 
 		@Override

--- a/src/main/java/hudson/plugins/robot/RobotBuildAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotBuildAction.java
@@ -200,10 +200,10 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 	}
 
 	/**
-	 * Get ratio of passed tests per total tests. Accounts for only critical tests run.
+	 * Get ratio of passed tests per total tests. Accounts for all tests run and skipped.
 	 * @return percent number
 	 */
-	public double getCriticalPassPercentage() {
+	public double getPassPercentageWithSkipped() {
 		return getResult().getPassPercentage(true);
 	}
 
@@ -282,7 +282,6 @@ public class RobotBuildAction extends AbstractTestResultAction<RobotBuildAction>
 				Boolean.parseBoolean(req.getParameter("zoomSignificant")), false,
 				Boolean.parseBoolean(req.getParameter("hd")),
 				Boolean.parseBoolean(req.getParameter("failedOnly")),
-				Boolean.parseBoolean(req.getParameter("criticalOnly")),
 				labelFormat,
 				Integer.parseInt(maxBuildsReq));
 		g.doPng(req, rsp);

--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -287,7 +287,6 @@ public class RobotParser {
 			caseResult.setLogFile(this.logFileName);
 			//parse attributes
 			caseResult.setName(reader.getAttributeValue(null, "name"));
-			//setCriticalityIfAvailable(reader, caseResult);
 			caseResult.setId(reader.getAttributeValue(null, "id"));
 			//parse test tags
 			caseResult.setDescription("");
@@ -340,7 +339,6 @@ public class RobotParser {
 			if (schemaVersion >= 5) {
 				caseResult.setElapsedTime(reader.getAttributeValue(null, elapsedLocalName));
 			}
-//			setCriticalityIfAvailable(reader, caseResult);
 			while(reader.hasNext()){
 				reader.next();
 				if(reader.isCharacters()){
@@ -572,13 +570,6 @@ public class RobotParser {
 				reader.next();
 			}
 			return stringBuilder.toString();
-		}
-
-		private static void setCriticalityIfAvailable(XMLStreamReader reader, RobotCaseResult caseResult) {
-			String criticality = reader.getAttributeValue(null, "critical");
-			if (criticality != null) {
-				caseResult.setCritical(criticality.equals("yes"));
-			}
 		}
 
 		@Override

--- a/src/main/java/hudson/plugins/robot/RobotProjectAction.java
+++ b/src/main/java/hudson/plugins/robot/RobotProjectAction.java
@@ -95,7 +95,6 @@ public class RobotProjectAction implements Action {
 			+ "/graph?zoomSignificant="+Boolean.valueOf(req.getParameter("zoomSignificant"))
 			+ "&hd="+Boolean.valueOf(req.getParameter("hd"))
 			+ "&failedOnly="+Boolean.valueOf(req.getParameter("failedOnly"))
-			+ "&criticalOnly="+Boolean.valueOf(req.getParameter("criticalOnly"))
 			+ "&maxBuildsToShow="+Integer.valueOf(req.getParameter("maxBuildsToShow")));
 
 	}

--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -73,7 +73,6 @@ public class RobotPublisher extends Recorder implements Serializable,
     final private boolean enableCache;
 
     //Default to true
-    private boolean onlyCritical = true;
     private boolean countSkippedTests = false;
 
     /**
@@ -87,7 +86,6 @@ public class RobotPublisher extends Recorder implements Serializable,
      * @param logFileName          Name of Robot log html
      * @param passThreshold        Threshold of test pass percentage for successful builds
      * @param unstableThreshold    Threshold of test pass percentage for unstable builds
-     * @param onlyCritical         True if only critical tests are included in pass percentage
      * @param otherFiles           Other files to be saved
      * @param enableCache          True if caching is used
      */
@@ -95,7 +93,7 @@ public class RobotPublisher extends Recorder implements Serializable,
     public RobotPublisher(String archiveDirName, String outputPath, String outputFileName,
                           boolean disableArchiveOutput, String reportFileName, String logFileName,
                           double passThreshold, double unstableThreshold,
-                          boolean onlyCritical, boolean countSkippedTests, String otherFiles, boolean enableCache, String overwriteXAxisLabel) {
+                          boolean countSkippedTests, String otherFiles, boolean enableCache, String overwriteXAxisLabel) {
         this.archiveDirName = archiveDirName;
         this.outputPath = outputPath;
         this.outputFileName = outputFileName;
@@ -104,7 +102,6 @@ public class RobotPublisher extends Recorder implements Serializable,
         this.passThreshold = passThreshold;
         this.unstableThreshold = unstableThreshold;
         this.logFileName = logFileName;
-        this.onlyCritical = onlyCritical;
         this.countSkippedTests = countSkippedTests;
         this.enableCache = enableCache;
         this.overwriteXAxisLabel = overwriteXAxisLabel;
@@ -203,15 +200,6 @@ public class RobotPublisher extends Recorder implements Serializable,
     }
 
     /**
-     * Gets if only critical tests should be accounted for the thresholds.
-     *
-     * @return true if only critical tests should be accounted for the thresholds
-     */
-    public boolean getOnlyCritical() {
-        return onlyCritical;
-    }
-
-    /**
      * Gets if skipped tests should be counted in the thresholds.
      *
      * @return true if skipped tests should be counted in the thresholds
@@ -274,7 +262,6 @@ public class RobotPublisher extends Recorder implements Serializable,
         if (build.getResult() != Result.ABORTED) {
             PrintStream logger = listener.getLogger();
             logger.println(Messages.robot_publisher_started());
-            logger.println(Messages.robot_publisher_only_critical());
             logger.println(Messages.robot_publisher_parsing());
             RobotResult result;
 

--- a/src/main/java/hudson/plugins/robot/RobotStep.java
+++ b/src/main/java/hudson/plugins/robot/RobotStep.java
@@ -37,7 +37,6 @@ public class RobotStep extends Step {
 	private double unstableThreshold;
 	private @CheckForNull String[] otherFiles;
 	private boolean enableCache = true;
-	private boolean onlyCritical = true;
 	private boolean countSkippedTests = false;
 	private @CheckForNull String overwriteXAxisLabel;
 
@@ -92,10 +91,6 @@ public class RobotStep extends Step {
 		return this.enableCache;
 	}
 	
-	public boolean getOnlyCritical() {
-		return this.onlyCritical;
-	}
-
 	public boolean getCountSkippedTests() { return this.countSkippedTests; }
 
 	public String getOverwriteXAxisLabel() {
@@ -142,11 +137,6 @@ public class RobotStep extends Step {
 		this.enableCache = enableCache;
 	}
 	
-	@DataBoundSetter
-	public void setOnlyCritical(boolean onlyCritical) {
-		this.onlyCritical = onlyCritical;
-	}
-
 	@DataBoundSetter
 	public void setCountSkippedTests(boolean countSkippedTests) {
 		this.countSkippedTests = countSkippedTests;

--- a/src/main/java/hudson/plugins/robot/RobotStepExecution.java
+++ b/src/main/java/hudson/plugins/robot/RobotStepExecution.java
@@ -29,7 +29,7 @@ public class RobotStepExecution extends SynchronousNonBlockingStepExecution<Void
     @Override protected Void run() throws Exception {
     	FilePath workspace = getContext().get(FilePath.class);
         workspace.mkdirs();
-    	RobotPublisher rp = new RobotPublisher(step.getArchiveDirName(), step.getOutputPath(), step.getOutputFileName(), step.getDisableArchiveOutput(), step.getReportFileName(), step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), step.getOnlyCritical(), step.getCountSkippedTests(), step.getOtherFiles(), step.getEnableCache(), step.getOverwriteXAxisLabel());
+    	RobotPublisher rp = new RobotPublisher(step.getArchiveDirName(), step.getOutputPath(), step.getOutputFileName(), step.getDisableArchiveOutput(), step.getReportFileName(), step.getLogFileName(), step.getPassThreshold(), step.getUnstableThreshold(), step.getCountSkippedTests(), step.getOtherFiles(), step.getEnableCache(), step.getOverwriteXAxisLabel());
     	rp.perform(getContext().get(Run.class), workspace, getContext().get(EnvVars.class), getContext().get(Launcher.class), getContext().get(TaskListener.class));
     	return null;
     }

--- a/src/main/java/hudson/plugins/robot/graph/RobotGraphHelper.java
+++ b/src/main/java/hudson/plugins/robot/graph/RobotGraphHelper.java
@@ -36,7 +36,6 @@ public class RobotGraphHelper {
 	 * Create a test result trend graph. The graph will ignore builds with no robot results.
 	 * @param significantData True if graph has significant data
 	 * @param binarydata Binary data
-	 * @param criticalOnly True if graph only critical tests
 	 * @param hd True if you want a larger image
 	 * @param labelFormat Label format
 	 * @param rootObject The dataset will be taken from rootObject backwards.
@@ -51,7 +50,6 @@ public class RobotGraphHelper {
 																 boolean binarydata,
 																 boolean hd,
 																 boolean failedOnly,
-																 boolean criticalOnly,
 																 String labelFormat,
 																 int maxBuildsToShow) {
 		List<Number> values = new ArrayList<>();
@@ -65,14 +63,14 @@ public class RobotGraphHelper {
 			 testObject != null && buildsLeftToShow != 0;
 			 testObject = testObject.getPreviousResult(), buildsLeftToShow--)
 		{
-			Number failed =  !criticalOnly ? testObject.getFailed() : testObject.getCriticalFailed();
+			Number failed =  testObject.getFailed();
 			Number passed = 0;
 			Number skipped = 0;
 			int compareLowerBoundTo;
 			if ( failedOnly) {
 			    compareLowerBoundTo = failed.intValue();
 			} else {
-			    passed = !criticalOnly ? testObject.getPassed() : testObject.getCriticalPassed();
+			    passed = testObject.getPassed();
 			    skipped = testObject.getSkipped();
 			    compareLowerBoundTo = passed.intValue();
 			}

--- a/src/main/java/hudson/plugins/robot/model/RobotCaseComparator.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseComparator.java
@@ -29,11 +29,6 @@ public class RobotCaseComparator implements Comparator<RobotCaseResult>, Seriali
 		if (!result1.isPassed()) {
 			if (result2.isPassed())
 				return -1;
-			if (result1.isCritical()) {
-				if (!result2.isCritical())
-					return -1;
-			} else if (result2.isCritical())
-				return 1;
 		} else if (!result2.isPassed())
 			return 1;
 		return result1.getRelativePackageName(result1).compareTo(result2.getRelativePackageName(result2));

--- a/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
@@ -43,7 +43,6 @@ public class RobotCaseResult extends RobotTestObject{
 
 	private boolean passed;
 	private boolean skipped;
-	private boolean critical;
 	private String errorMsg;
 	private String name;
 	private String description;
@@ -174,10 +173,6 @@ public class RobotCaseResult extends RobotTestObject{
 		this.skipped = skipped;
 	}
 
-	public void setCritical(boolean critical) {
-		this.critical = critical;
-	}
-
 	public String getDisplayName() {
 		return getName();
 	}
@@ -192,10 +187,6 @@ public class RobotCaseResult extends RobotTestObject{
 
 	public boolean isSkipped() {
 		return skipped;
-	}
-
-	public boolean isCritical() {
-		return critical;
 	}
 
 	public List<String> getTags(){
@@ -291,7 +282,7 @@ public class RobotCaseResult extends RobotTestObject{
 		String label = getParentAction().getxAxisLabel();
 		String labelFormat = StringUtils.isBlank(label) ? RobotConfig.getInstance().getXAxisLabelFormat() : label;
 		Graph g = RobotGraphHelper.createTestResultsGraphForTestObject(this, false, true,
-				  Boolean.parseBoolean(req.getParameter("hd")), false, false, labelFormat,
+				  Boolean.parseBoolean(req.getParameter("hd")), false, labelFormat,
 				  Integer.parseInt(req.getParameter("maxBuildsToShow")));
 		g.doPng(req, rsp);
 	}
@@ -312,17 +303,5 @@ public class RobotCaseResult extends RobotTestObject{
 	public int getSkipped() {
 		if (isSkipped()) return 1;
 		return 0;
-	}
-
-	@Deprecated
-	@Override
-	public long getCriticalFailed() {
-		return this.getFailed();
-	}
-
-	@Deprecated
-	@Override
-	public long getCriticalPassed() {
-		return this.getPassed();
 	}
 }

--- a/src/main/java/hudson/plugins/robot/model/RobotResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotResult.java
@@ -53,7 +53,7 @@ public class RobotResult extends RobotTestObject {
 
 	private String timeStamp;
 
-	private transient int passed, failed, skipped, criticalPassed, criticalFailed;
+	private transient int passed, failed, skipped;
 
 	//backwards compatibility with old builds
 	private transient List<RobotResultStatistics> overallStats;
@@ -82,36 +82,6 @@ public class RobotResult extends RobotTestObject {
 	@Override
 	public String getDescription() {
 		return "";
-	}
-
-	/**
-	 * Get number of passed critical tests.
-	 * @return number of passed critical tests
-	 */
-	@Deprecated
-	@Exported
-	public long getCriticalPassed(){
-		return this.getOverallPassed();
-	}
-
-	/**
-	 * Get number of failed critical tests.
-	 * @return number of failed critical tests
-	 */
-	@Deprecated
-	@Exported
-	public long getCriticalFailed(){
-		return this.getOverallFailed();
-	}
-
-	/**
-	 * Get total number of critical tests.
-	 * @return total number of critical tests
-	 */
-	@Deprecated
-	@Exported
-	public long getCriticalTotal(){
-		return this.getOverallTotal();
 	}
 
 	/**
@@ -160,7 +130,7 @@ public class RobotResult extends RobotTestObject {
 
 	/**
 	 * Get pass/fail stats by category.
-	 * @return List containing 'critical tests' and 'all tests'
+	 * @return List containing 'all tests'
 	 */
 	public List<RobotResultStatistics> getStatsByCategory() {
 		return overallStats;
@@ -407,8 +377,6 @@ public class RobotResult extends RobotTestObject {
 		failed = 0;
 		passed = 0;
 		skipped = 0;
-		criticalPassed = 0;
-		criticalFailed = 0;
 		duration = 0;
 
 		Collection<RobotSuiteResult> newSuites = getSuites();
@@ -419,8 +387,6 @@ public class RobotResult extends RobotTestObject {
 			failed += suite.getFailed();
 			passed += suite.getPassed();
 			skipped += suite.getSkipped();
-			criticalFailed += suite.getFailed();
-			criticalPassed += suite.getPassed();
 			duration += suite.getDuration();
 			newMap.put(suite.getDuplicateSafeName(), suite);
 		}

--- a/src/main/java/hudson/plugins/robot/model/RobotSuiteResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotSuiteResult.java
@@ -48,8 +48,6 @@ public class RobotSuiteResult extends RobotTestObject {
 	private transient int failed;
 	private transient int passed;
 	private transient int skipped;
-	private transient int criticalPassed;
-	private transient int criticalFailed;
 
 	private int schemaVersion;
 
@@ -158,33 +156,6 @@ public class RobotSuiteResult extends RobotTestObject {
 	 */
 	public int getTotal() {
 		return passed + failed + skipped;
-	}
-
-	/**
-	 * Get number of passed critical tests
-	 * @return number of passed critical tests
-	 */
-	@Deprecated
-	public long getCriticalPassed() {
-		return this.getPassed();
-	}
-
-	/**
-	 * Get number of failed critical tests
-	 * @return number of failed critical tests
-	 */
-	@Deprecated
-	public long getCriticalFailed() {
-		return this.getFailed();
-	}
-
-	/**
-	 * Get number of all critical tests
-	 * @return number of all critical tests
-	 */
-	@Deprecated
-	public int getCriticalTotal() {
-		return this.getTotal();
 	}
 
 	public void setSchemaVersion(int version) {
@@ -401,19 +372,15 @@ public class RobotSuiteResult extends RobotTestObject {
 		failed = 0;
 		passed = 0;
 		skipped = 0;
-		criticalPassed = 0;
-		criticalFailed = 0;
 		duration = 0;
 
 		HashMap<String, RobotCaseResult> newCases = new HashMap<>();
 		for(RobotCaseResult caseResult : getCaseResults()) {
 			if(caseResult.isPassed()) {
-				if(caseResult.isCritical()) criticalPassed++;
 				passed++;
 			} else if(caseResult.isSkipped()) {
 				skipped++;
 			} else {
-				if(caseResult.isCritical()) criticalFailed++;
 				failed++;
 			}
 			duration += caseResult.getDuration();
@@ -428,8 +395,6 @@ public class RobotSuiteResult extends RobotTestObject {
 			failed += suite.getFailed();
 			passed += suite.getPassed();
 			skipped += suite.getSkipped();
-			criticalFailed += suite.getFailed();
-			criticalPassed += suite.getPassed();
 			duration += suite.getDuration();
 			newSuites.put(suite.getDuplicateSafeName(), suite);
 		}

--- a/src/main/java/hudson/plugins/robot/model/RobotTestObject.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotTestObject.java
@@ -249,10 +249,6 @@ public abstract class RobotTestObject extends AbstractModelObject implements Ser
 
 	public abstract int getSkipped();
 
-	public abstract long getCriticalPassed();
-
-	public abstract long getCriticalFailed();
-
 	/**
 	 * Return robot trend graph in the request.
 	 * @param req StaplerRequest
@@ -268,7 +264,6 @@ public abstract class RobotTestObject extends AbstractModelObject implements Ser
 				Boolean.parseBoolean(req.getParameter("zoomSignificant")),
 				false, Boolean.parseBoolean(req.getParameter("hd")),
 				Boolean.parseBoolean(req.getParameter("failedOnly")),
-				Boolean.parseBoolean(req.getParameter("criticalOnly")),
 				labelFormat,
 				Integer.parseInt(req.getParameter("maxBuildsToShow")));
 		g.doPng(req, rsp);

--- a/src/main/java/hudson/plugins/robot/tokens/RobotFailTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotFailTokenMacro.java
@@ -15,9 +15,6 @@ import java.io.IOException;
 @Extension(optional = true)
 public class RobotFailTokenMacro extends DataBoundTokenMacro {
 
-	@Parameter
-	public boolean onlyCritical;
-
 	@Override
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
@@ -16,8 +16,9 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 @Extension(optional = true)
 public class RobotPassRatioTokenMacro extends DataBoundTokenMacro {
 
+	// Default to true to retain previous behavior, false to ignore skipped tests as part of the total
 	@Parameter
-	public boolean countSkippedTests;
+	public boolean countSkippedTests = true;
 
 	@Override
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro.java
@@ -17,7 +17,7 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 public class RobotPassRatioTokenMacro extends DataBoundTokenMacro {
 
 	@Parameter
-	public boolean onlyCritical;
+	public boolean countSkippedTests;
 
 	@Override
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
@@ -33,7 +33,9 @@ public class RobotPassRatioTokenMacro extends DataBoundTokenMacro {
 		RobotBuildAction action = context.getAction(RobotBuildAction.class);
 		if(action!=null){
 			RobotResult result = action.getResult();
-			return result.getOverallPassed() + " / " + result.getOverallTotal();
+			long passed = result.getOverallPassed();
+			long total = countSkippedTests ? result.getOverallTotal() : result.getOverallTotal() - result.getOverallSkipped();
+			return passed + " / " + total;
 		}
 		return "";
 	}

--- a/src/main/java/hudson/plugins/robot/tokens/RobotPassTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotPassTokenMacro.java
@@ -15,9 +15,6 @@ import java.io.IOException;
 @Extension(optional = true)
 public class RobotPassTokenMacro extends DataBoundTokenMacro {
 
-	@Parameter
-	public boolean onlyCritical;
-
 	@Override
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,

--- a/src/main/java/hudson/plugins/robot/tokens/RobotTotalTokenMacro.java
+++ b/src/main/java/hudson/plugins/robot/tokens/RobotTotalTokenMacro.java
@@ -15,9 +15,6 @@ import java.io.IOException;
 @Extension(optional = true)
 public class RobotTotalTokenMacro extends DataBoundTokenMacro {
 
-	@Parameter
-	public boolean onlyCritical;
-
 	@Override
 	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,
 			String macroName) throws MacroEvaluationException, IOException,

--- a/src/main/resources/hudson/plugins/robot/AggregatedRobotAction/index.jelly
+++ b/src/main/resources/hudson/plugins/robot/AggregatedRobotAction/index.jelly
@@ -24,8 +24,8 @@ limitations under the License.
                 <div style="border: 1px solid gray; margin-bottom: 20px; padding: 10px" >
                 <h2>Configuration: ${run.parent.displayName}</h2>
                 <div style="float:right">
-                <a href="${run.project.absoluteUrl}${run.number}/robot"><img title="Browse results" src="${run.project.absoluteUrl}${run.number}/robot/graph?zoomSignificant=true&amp;failedOnly=false&amp;criticalOnly=false&amp;maxBuildsToShow=0" width="500" height="200"/></a><br/>
-                <p style="float:right"><a href="graph?hd=true&amp;zoomSignificant=true&amp;failedOnly=false&amp;criticalOnly=false&amp;maxBuildsToShow=0">Show bigger image</a></p>
+                <a href="${run.project.absoluteUrl}${run.number}/robot"><img title="Browse results" src="${run.project.absoluteUrl}${run.number}/robot/graph?zoomSignificant=true&amp;failedOnly=false&amp;maxBuildsToShow=0" width="500" height="200"/></a><br/>
+                <p style="float:right"><a href="graph?hd=true&amp;zoomSignificant=true&amp;failedOnly=false&amp;maxBuildsToShow=0">Show bigger image</a></p>
                 </div>
                 <u:robotsummary action="${it.getChildBuildAction(run)}"/>
                 <div style="clear: both" />

--- a/src/main/resources/hudson/plugins/robot/Messages.properties
+++ b/src/main/resources/hudson/plugins/robot/Messages.properties
@@ -23,7 +23,6 @@ robot.publisher.finished=Done publishing Robot results.
 robot.publisher.done= Done!
 robot.publisher.fail= Failed!
 
-robot.publisher.only_critical=INFO: Checking test criticality is deprecated and will be dropped in a future release!
 robot.publisher.file_not_found=WARNING! Could not find file:
 
 robot.config.percentvalidation=Entry must be percentage value between 0-100

--- a/src/main/resources/hudson/plugins/robot/RobotProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotProjectAction/floatingBox.jelly
@@ -28,7 +28,6 @@ limitations under the License.
             <span id="robot-fromurl-id" data-url="${from.urlName}/"></span>
             <p><label><input type="checkbox" id="zoomToChanges"/>Zoom to changes</label></p>
             <p><label><input type="checkbox" id="failedOnly"/>Show only failed</label></p>
-            <p><label><input type="checkbox" id="criticalOnly"/>Show only critical</label></p>
             <p><label><input min="0" max="9999" step="1" placeholder="all" value="" type="number" id="maxBuildsToShow"/>Max builds</label></p>
             <br/><p style="float:right"><a id="passfailgraph_hd_link" href="">Show bigger image</a></p>
         </div>

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.jelly
@@ -53,9 +53,6 @@ limitations under the License.
     <f:entry title="&lt;img src=&quot;${rootURL}/images/16x16/blue.gif&quot;/&gt; %" field="passThreshold">
            <f:textbox />
     </f:entry>
-    <f:entry field="onlyCritical">
-        <f:checkbox default="true"/>${%thresholds.onlyCritical}
-    </f:entry>
     <f:entry field="countSkippedTests">
         <f:checkbox default="false"/>${%thresholds.countSkippedTests}
     </f:entry>

--- a/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotPublisher/config.properties
@@ -21,5 +21,4 @@ advanced.overwriteXAxisLabel.description=Overwrite default x-axis label for publ
 
 
 thresholds.label=Thresholds for build result
-thresholds.onlyCritical=DEPRECATED! THIS FLAG DOES NOTHING! - Use thresholds for critical tests only
 thresholds.countSkippedTests=Include skipped tests in total count for thresholds

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.jelly
@@ -53,9 +53,6 @@ limitations under the License.
     <f:entry title="&lt;img src=&quot;${rootURL}/images/16x16/blue.gif&quot;/&gt; %" field="passThreshold">
            <f:textbox />
     </f:entry>
-    <f:entry field="onlyCritical">
-        <f:checkbox default="true"/>${%thresholds.onlyCritical}
-    </f:entry>
     <f:entry field="countSkippedTests">
         <f:checkbox default="false"/>${%thresholds.countSkippedTests}
     </f:entry>

--- a/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
+++ b/src/main/resources/hudson/plugins/robot/RobotStep/config.properties
@@ -20,5 +20,4 @@ advanced.overwriteXAxisLabel=X-axis label
 advanced.overwriteXAxisLabel.description=Overwrite default x-axis label for publish trend
 
 thresholds.label=Thresholds for build result
-thresholds.onlyCritical=DEPRECATED! THIS FLAG DOES NOTHING! - Use thresholds for critical tests only
 thresholds.countSkippedTests=Include skipped tests in total count for thresholds

--- a/src/main/resources/hudson/plugins/robot/model/RobotCaseResult/index.jelly
+++ b/src/main/resources/hudson/plugins/robot/model/RobotCaseResult/index.jelly
@@ -35,11 +35,11 @@ limitations under the License.
       <j:set var="prevcase" value="${it.previousResult}" />
       <table class="summary">
       <tbody>
-      <tr><th class="${status}">TEST CASE:</th><td><strong>${it.name}</strong><j:if test="${!it.critical}"> (non-critical)</j:if></td></tr>
+      <tr><th class="${status}">TEST CASE:</th><td><strong>${it.name}</strong></td></tr>
       <tr><th>Tags:</th><td>${it.commaSeparatedTags}</td></tr>
       <tr><th>Description:</th><td>${it.description}</td></tr>
       <tr><th>Duration:</th><td>${it.humanReadableDuration} (${it.getDurationDiff(prevcase)})</td></tr>
-      <tr><th>Status:</th><td><span class="${status}">${status}</span> (<j:if test="${!it.critical}">non-</j:if>critical)</td></tr>
+      <tr><th>Status:</th><td><span class="${status}">${status}</span></td></tr>
       <j:if test="${!it.isPassed()}">
         <tr><th>Message:</th><td class="error-message">${it.errorMsg}</td></tr>
       </j:if>

--- a/src/main/resources/hudson/plugins/robot/model/RobotResult/index.jelly
+++ b/src/main/resources/hudson/plugins/robot/model/RobotResult/index.jelly
@@ -29,22 +29,13 @@ limitations under the License.
           <j:set var="total_status" value="PASS" />
       </j:otherwise>
     </j:choose>
-    <j:choose>
-      <j:when test="${it.criticalFailed > 0}">
-          <j:set var="status" value="FAIL" />
-      </j:when>
-      <j:otherwise>
-          <j:set var="status" value="PASS" />
-      </j:otherwise>
-    </j:choose>
     <j:set var="prevresult" value="${it.previousResult}" />
       <h1 class="${status}">Robot Framework Test Results</h1>
       <table class="summary">
       <tbody>
         <tr><th>Executed:</th><td>${it.timeStamp}</td></tr>
         <tr><th>Duration:</th><td>${it.humanReadableDuration} (${it.getDurationDiff(prevresult)})</td></tr>
-        <tr><th>Status:</th><td>${it.criticalTotal} critical test, ${it.criticalPassed} passed, <span class="${status}">${it.criticalFailed}</span> failed, 0 skipped<br/>
-                              ${it.overallTotal} test total (${h.getDiffString(it.total - prevresult.total)}), ${it.passed} passed, <span class="${total_status}">${it.failed}</span> failed, ${it.skipped} skipped</td></tr>
+        <tr><th>Status:</th><td>${it.overallTotal} test total (${h.getDiffString(it.total - prevresult.total)}), ${it.passed} passed, <span class="${total_status}">${it.failed}</span> failed, ${it.skipped} skipped</td></tr>
         <tr><th>Results:</th><td>
                              <j:if test="${it.hasReport}"><a href="${rootURL}/${it.parentAction.owner.url}${it.parentAction.urlName}/report/${it.reportFile}">${it.reportFile}</a><br/></j:if>
                              <j:if test="${it.hasLog}"><a href="${rootURL}/${it.parentAction.owner.url}${it.parentAction.urlName}/report/${it.logFile}">${it.logFile}</a><br/></j:if>
@@ -61,7 +52,6 @@ limitations under the License.
         <span id="robot-fromurl-id" data-url=""></span>
         <p><label><input type="checkbox" id="zoomToChanges"/>Zoom to changes</label></p>
         <p><label><input type="checkbox" id="failedOnly"/>Show only failed</label></p>
-        <p><label><input type="checkbox" id="criticalOnly"/>Show only critical</label></p>
         <p><label><input min="0" max="9999" step="1" placeholder="all" value="" type="number" id="maxBuildsToShow"/>Max builds</label></p>
         <br/><p style="float:right"><a id="passfailgraph_hd_link" href="">Show bigger image</a></p>
        </div>

--- a/src/main/resources/hudson/plugins/robot/model/RobotSuiteResult/index.jelly
+++ b/src/main/resources/hudson/plugins/robot/model/RobotSuiteResult/index.jelly
@@ -29,22 +29,13 @@ limitations under the License.
           <j:set var="total_status" value="PASS" />
       </j:otherwise>
     </j:choose>
-    <j:choose>
-      <j:when test="${it.criticalFailed > 0}">
-          <j:set var="status" value="FAIL" />
-      </j:when>
-      <j:otherwise>
-          <j:set var="status" value="PASS" />
-      </j:otherwise>
-    </j:choose>
     <j:set var="prevresult" value="${it.previousResult}" />
       <table class="summary">
       <tbody>
         <tr><th class="${status}">TEST SUITE:</th><td><strong>${it.name}</strong></td></tr>
         <tr><th>Description:</th><td>${it.description}</td></tr>
         <tr><th>Duration:</th><td>${it.humanReadableDuration} (${it.getDurationDiff(prevresult)})</td></tr>
-        <tr><th>Status:</th><td>${it.criticalTotal} critical test, ${it.criticalPassed} passed, <span class="${status}">${it.criticalFailed}</span> failed, 0 skipped<br/>
-                              ${it.total} test total (${h.getDiffString(it.total - prevresult.total)}), ${it.passed} passed, <span class="${total_status}">${it.failed}</span> failed, ${it.skipped} skipped</td></tr>
+        <tr><th>Status:</th><td>${it.total} test total (${h.getDiffString(it.total - prevresult.total)}), ${it.passed} passed, <span class="${total_status}">${it.failed}</span> failed, ${it.skipped} skipped</td></tr>
         <j:if test="${it.hasReport}">
           <tr><th>Report File:</th><td><a href="${rootURL}/${it.parentAction.owner.url}${it.parentAction.urlName}/report/${it.reportFile}#suites?${it.id}">${it.reportFile}</a></td></tr>
         </j:if>
@@ -62,7 +53,6 @@ limitations under the License.
         <span id="robot-fromurl-id" data-url=""></span>
         <p><label><input type="checkbox" id="zoomToChanges"/>Zoom to changes</label></p>
         <p><label><input type="checkbox" id="failedOnly"/>Show only failed</label></p>
-        <p><label><input type="checkbox" id="criticalOnly"/>Show only critical</label></p>
         <p><label><input min="0" step="1" max="9999" value="" placeholder="all" type="number" id="maxBuildsToShow"/>Max builds</label></p>
         <br/><p style="float:right"><a id="passfailgraph_hd_link" href="">Show bigger image</a></p>
        </div>
@@ -80,7 +70,6 @@ limitations under the License.
       <table class="pane sortable">
         <tr>
             <td class="pane-header" title="Test case name. Click to sort.">Name</td>
-            <td class="pane-header" style="text-align:center;" title="Criticality. Click to sort.">Crit.</td>
             <td class="pane-header" style="text-align:center;" title="Status. Click to sort.">Status</td>
             <td class="pane-header" title="Duration and difference to previous build. Click to sort.">Duration <span style="font-size:0.8em">(diff)</span></td>
         </tr>
@@ -100,7 +89,6 @@ limitations under the License.
 
         <tr>
          <td class="pane"><a href="${case.getRelativeId(it)}">${case.name}</a></td>
-         <td class="pane" style="text-align:center;"><j:if test="${case.isCritical()}">yes</j:if><j:if test="${!case.isCritical()}">no</j:if></td>
          <td class="pane ${status}" style="text-align:center;">${status}</td>
          <td class="pane">${case.humanReadableDuration}<span style="font-size:0.8em">(${case.getDurationDiff(prevcase)})</span></td>
         </tr>

--- a/src/main/resources/hudson/plugins/robot/tokens/RobotFailTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/robot/tokens/RobotFailTokenMacro/help.jelly
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>	
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <dt>$${ROBOT_FAILEd, onlyCritical}</dt>
+  <dt>$${ROBOT_FAILED}</dt>
   <dd>
     Expands to build number of failed tests.
-    <ul>
-        <li><i>onlyCritical</i> - True if number should contain only critical failed tests.<br />Defaults to false.</li>
-    </ul>
   </dd>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacro/help.jelly
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>	
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <dt>$${ROBOT_PASSPERCENTAGE, onlyCritical}</dt>
+  <dt>$${ROBOT_PASSPERCENTAGE, countSkipped}</dt>
   <dd>
     Expands to pass percentage of tests. (passed / total * 100 %)
     <ul>
-        <li><i>onlyCritical</i> - True if only critical tests should be calculated in percentage<br />Defaults to false.</li>
+        <li><i>countSkipped</i> - True if also skipped tests should be calculated in percentage<br />Defaults to false.</li>
     </ul>
   </dd>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/robot/tokens/RobotPassRatioTokenMacro/help.jelly
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>	
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <dt>$${ROBOT_PASSRATIO, onlyCritical}</dt>
+  <dt>$${ROBOT_PASSRATIO, countSkipped}</dt>
   <dd>
     Expands to build result in 'passed / total' format.
     <ul>
-        <li><i>onlyCritical</i> - True if only critical tests should be calculated in percentage<br />Defaults to false.</li>
+        <li><i>countSkipped</i> - True if also skipped tests should be calculated in percentage<br />Defaults to false.</li>
     </ul>
   </dd>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/robot/tokens/RobotPassTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/robot/tokens/RobotPassTokenMacro/help.jelly
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>	
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <dt>$${ROBOT_PASSED, onlyCritical}</dt>
+  <dt>$${ROBOT_PASSED}</dt>
   <dd>
     Expands to build number of passed tests.
-    <ul>
-        <li><i>onlyCritical</i> - True if number should contain only critical passed tests.<br />Defaults to false.</li>
-    </ul>
   </dd>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/robot/tokens/RobotTotalTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/robot/tokens/RobotTotalTokenMacro/help.jelly
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>	
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <dt>$${ROBOT_TOTAL, onlyCritical}</dt>
+  <dt>$${ROBOT_TOTAL}</dt>
   <dd>
     Expands to total number of tests.
-    <ul>
-        <li><i>onlyCritical</i> - True if number should contain only critical tests.<br />Defaults to false.</li>
-    </ul>
   </dd>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/robot/util/failedCases.jelly
+++ b/src/main/resources/hudson/plugins/robot/util/failedCases.jelly
@@ -12,7 +12,6 @@
         <table class="pane sortable">
             <tr>
                 <td class="pane-header" title="Test case name. Click to sort.">Name</td>
-                <td class="pane-header" style="text-align:center !important;" title="Criticality. Click to sort.">Crit.</td>
                 <td class="pane-header" title="Duration. Click to sort.">Duration</td>
                 <td class="pane-header" style="text-align:center;" title="Number of failed builds. Click to sort.">Age</td>
             </tr>
@@ -30,7 +29,6 @@
                             ${%Loading...}
                         </div>
                     </td>
-                    <td class="pane" style="text-align:center;"><j:if test="${case.isCritical()}">yes</j:if><j:if test="${!case.isCritical()}">no</j:if></td>
                     <td class="pane">${case.humanReadableDuration}</td>
                     <td class="pane" style="text-align:center;"><a href="${rootURL}/${case.failedSinceRun.url}">${case.age}</a></td>
                 </tr>

--- a/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
+++ b/src/main/resources/hudson/plugins/robot/util/robotsummary.jelly
@@ -67,7 +67,7 @@ limitations under the License.
             <td>
                 <j:set var="totalPassPercentage" value="${attrs.action.overallPassPercentage}"/>
                 <j:if test="${attrs.action.countSkippedTests}">
-                    <j:set var="totalPassPercentage" value="${attrs.action.criticalPassPercentage}"/>
+                    <j:set var="totalPassPercentage" value="${attrs.action.getPassPercentageWithSkipped}"/>
                 </j:if>
                 ${totalPassPercentage}
             </td>

--- a/src/main/resources/hudson/plugins/robot/util/robotsummary.properties
+++ b/src/main/resources/hudson/plugins/robot/util/robotsummary.properties
@@ -11,7 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-critical.ratio=Pass ratio (Critical tests): {0}%
 all.ratio=Pass ratio (All tests): {0}%
-critical.amount=Tests passed (Critical tests): {0}/{1}
 all.amount=Tests passed (All tests): {0}/{1}

--- a/src/main/webapp/help-thresholds.html
+++ b/src/main/webapp/help-thresholds.html
@@ -16,5 +16,5 @@ limitations under the License.
 <div>
 <p>Specify thresholds for marking a build unstable or passed. Thresholds are expressed in percentage of tests that passed compared to total amount of tests run.
 Builds with pass percentage under the blue threshold wild be marked unstable and pass percentage under yellow threshold will yield a failed build.</p>
-<p>If "Use thresholds for critical tests only" is selected thresholds will be compared to the pass ratio of critical tests instead of all tests.</p>
+<p>If "Include skipped tests in total count for thresholds" is selected thresholds will be compared to the pass ratio of all tests instead of all executed tests.</p>
 </div>

--- a/src/main/webapp/robot.js
+++ b/src/main/webapp/robot.js
@@ -1,16 +1,13 @@
 function initPassFailGraph(target) {
     var mode = getCookie("RobotResult_zoom", "true");
     var failedOnly = getCookie("RobotResult_failedOnly", "false");
-    var criticalOnly = getCookie("RobotResult_criticalOnly", "false");
     var maxBuildsToShow = getCookie("RobotResult_maxBuildsToShow", 0);
     if (document.getElementById("zoomToChanges"))
         document.getElementById("zoomToChanges").checked = (mode == "true");
     if (document.getElementById("failedOnly"))
         document.getElementById("failedOnly").checked = (failedOnly == "true");
-    if (document.getElementById("criticalOnly"))
-        document.getElementById("criticalOnly").checked = (criticalOnly == "true");
     setMaxBuildsToShow(maxBuildsToShow);
-    setPassFailGraphSrc(target, mode, failedOnly, criticalOnly, maxBuildsToShow);
+    setPassFailGraphSrc(target, mode, failedOnly, maxBuildsToShow);
 }
 
 function initDurationGraph(target) {
@@ -34,11 +31,10 @@ function setLinks(graph, href) {
     document.getElementById(graph).src = href;
 }
 
-function setPassFailGraphSrc(target, mode, failedOnly, criticalOnly, maxBuildsToShow) {
+function setPassFailGraphSrc(target, mode, failedOnly, maxBuildsToShow) {
     var href = target + "graph?" +
                "zoomSignificant=" + mode +
                "&failedOnly=" + failedOnly +
-               "&criticalOnly=" + criticalOnly +
                "&maxBuildsToShow=" + maxBuildsToShow;
     setLinks("passfailgraph", href)
 }
@@ -61,16 +57,11 @@ function redrawPassFailGraph() {
         failedOnly = Boolean(document.getElementById('failedOnly').checked).toString();
         setCookie("RobotResult_failedOnly",failedOnly, 365);
     }
-    var criticalOnly = false;
-    if (document.getElementById("criticalOnly")) {
-        criticalOnly = Boolean(document.getElementById('criticalOnly').checked).toString();
-        setCookie("RobotResult_criticalOnly",criticalOnly, 365);
-    }
     var maxBuildsToShow = getMaxBuildsToShow();
     setMaxBuildsToShow(maxBuildsToShow);
     setCookie("RobotResult_maxBuildsToShow",maxBuildsToShow, 365);
 
-    setPassFailGraphSrc(target, mode, failedOnly, criticalOnly, maxBuildsToShow);
+    setPassFailGraphSrc(target, mode, failedOnly, maxBuildsToShow);
 }
 
 function redrawDurationGraph() {
@@ -120,7 +111,7 @@ document.addEventListener("DOMContentLoaded", function(){
     if (element) {
         var url = element.getAttribute("data-url");
 
-        ["zoomToChanges", "failedOnly", "criticalOnly"].forEach(function(id) {
+        ["zoomToChanges", "failedOnly"].forEach(function(id) {
             if (document.getElementById(id))
                 document.getElementById(id).addEventListener("click", redrawPassFailGraph);
         });

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -56,20 +56,20 @@ public class RobotPublisherSystemTest {
 	@Test
 	public void testRoundTripConfig() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testRoundTripConfig");
-		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, false,"dir1/*.jpg, dir2/*.png",
+		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
 				false, "");
 		p.getPublishersList().add(before);
 		j.configRoundtrip(p);
 		RobotPublisher after = p.getPublishersList().get(RobotPublisher.class);
 		assertThat(
-				"outputPath,outputFileName,reportFileName,logFileName,passThreshold,unstableThreshold,onlyCritical,countSkippedTests,otherFiles",
+				"outputPath,outputFileName,reportFileName,logFileName,passThreshold,unstableThreshold,countSkippedTests,otherFiles",
 				before, samePropertyValuesAs(after));
 	}
 
 	@Test
 	public void testConfigView() throws Exception {
 		FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "testConfigView");
-		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, false,"dir1/*.jpg, dir2/*.png",
+		RobotPublisher before = new RobotPublisher(null, "a", "b", false, "c", "d", 11, 27, true, "dir1/*.jpg, dir2/*.png",
 				false, "");
 		p.getPublishersList().add(before);
 		HtmlPage page = j.createWebClient().getPage(p, "configure");
@@ -193,7 +193,7 @@ public class RobotPublisherSystemTest {
 		WebAssert.assertElementPresentByXPath(page, "//div[@id='main-panel']//img[@id='passfailgraph']");
 		WebAssert.assertElementPresentByXPath(page,
 				"//div[@id='main-panel']//a[@href='/jenkins/job/oldrobotbuild/1/robot' and contains(text(),'Browse results')]");
-		this.verifyTotalsTable(page, 8, 4, 0, "50.0", 8, 4, "50.0");
+		this.verifyTotalsTable(page, 8, 4, 0, "50.0");
 
 		page = wc.goTo("job/oldrobotbuild/robot/");
 		WebAssert.assertTitleEquals(page, "Testcases & Othercases Test Report");
@@ -204,7 +204,7 @@ public class RobotPublisherSystemTest {
 		WebAssert.assertElementPresentByXPath(page, "//div[@id='main-panel']//h4[contains(.,'Robot Test Summary:')]");
 		WebAssert.assertElementPresentByXPath(page,
 				"//div[@id='main-panel']//a[@href='/jenkins/job/oldrobotbuild/1/robot' and contains(text(),'Browse results')]");
-		this.verifyTotalsTable(page, 8, 4, 0,"50.0", 8, 4, "50.0");
+		this.verifyTotalsTable(page, 8, 4, 0,"50.0");
 
 		page = wc.goTo("job/oldrobotbuild/1/robot/");
 		WebAssert.assertTitleEquals(page, "Testcases & Othercases Test Report");
@@ -225,7 +225,7 @@ public class RobotPublisherSystemTest {
 				"//div[@id='main-panel']//a[@href='/jenkins/job/robot/1/robot/report/report.html' and contains(text(), 'Open report.html')]");
 		WebAssert.assertElementPresentByXPath(page,
 				"//div[@id='main-panel']//a[@href='/jenkins/job/robot/1/robot/report/log.html' and contains(text(), 'Open log.html')]");
-		verifyTotalsTable(page, 8, 4, 0,"50.0", 8, 4, "50.0");
+		verifyTotalsTable(page, 8, 4, 0,"50.0");
 
 		page = wc.goTo("job/robot/1/");
 		WebAssert.assertElementPresentByXPath(page, "//div[@id='tasks']//a[@href='/jenkins/job/robot/1/robot']");
@@ -236,7 +236,7 @@ public class RobotPublisherSystemTest {
 				"//div[@id='main-panel']//a[@href='/jenkins/job/robot/1/robot/report/report.html' and contains(text(), 'Open report.html')]");
 		WebAssert.assertElementPresentByXPath(page,
 				"//div[@id='main-panel']//a[@href='/jenkins/job/robot/1/robot/report/log.html' and contains(text(), 'Open log.html')]");
-		verifyTotalsTable(page, 8, 4, 0,"50.0", 8, 4, "50.0");
+		verifyTotalsTable(page, 8, 4, 0,"50.0");
 	}
 
 	@LocalData
@@ -254,7 +254,7 @@ public class RobotPublisherSystemTest {
 				"//div[@id='main-panel']//a[@href='/jenkins/job/files-with-env-vars/1/robot/report/report_1.html' and contains(text(), 'Open report_1.html')]");
 		WebAssert.assertElementPresentByXPath(page,
 				"//div[@id='main-panel']//a[@href='/jenkins/job/files-with-env-vars/1/robot/report/log_1.html' and contains(text(), 'Open log_1.html')]");
-		verifyTotalsTable(page, 6, 1, 0,"83.3", 6, 1, "83.3");
+		verifyTotalsTable(page, 6, 1, 0,"83.3");
 
 		page = wc.goTo("job/files-with-env-vars/1/");
 		WebAssert.assertElementPresentByXPath(page, "//div[@id='tasks']//a[@href='/jenkins/job/files-with-env-vars/1/robot']");
@@ -265,7 +265,7 @@ public class RobotPublisherSystemTest {
 				"//div[@id='main-panel']//a[@href='/jenkins/job/files-with-env-vars/1/robot/report/report_1.html' and contains(text(), 'Open report_1.html')]");
 		WebAssert.assertElementPresentByXPath(page,
 				"//div[@id='main-panel']//a[@href='/jenkins/job/files-with-env-vars/1/robot/report/log_1.html' and contains(text(), 'Open log_1.html')]");
-		verifyTotalsTable(page, 6, 1, 0,"83.3", 6, 1, "83.3");
+		verifyTotalsTable(page, 6, 1, 0,"83.3");
 	}
 
 	@LocalData
@@ -273,7 +273,7 @@ public class RobotPublisherSystemTest {
 	public void testRobot29Outputs() throws Exception {
 		WebClient wc = this.executeJobAndGetWebClient("robot29output");
 		HtmlPage page = wc.goTo("job/robot29output/");
-		verifyTotalsTable(page, 1, 0, 0,"100.0", 1, 0, "100.0");
+		verifyTotalsTable(page, 1, 0, 0,"100.0");
 	}
 
 	@LocalData
@@ -292,7 +292,7 @@ public class RobotPublisherSystemTest {
 				"//div[@id='main-panel']//a[@href='/jenkins/job/several-outputs/1/robot/report/**/report.html' and contains(text(), 'Open **/report.html')]");
 		WebAssert.assertElementPresentByXPath(page,
 				"//div[@id='main-panel']//a[@href='/jenkins/job/several-outputs/1/robot/report/**/log.html' and contains(text(), 'Open **/log.html')]");
-		verifyTotalsTable(page, 2, 0, 0,"100.0", 2, 0, "100.0");
+		verifyTotalsTable(page, 2, 0, 0,"100.0");
 	}
 
 	@LocalData
@@ -472,8 +472,7 @@ public class RobotPublisherSystemTest {
 		return testProject;
 	}
 
-	private void verifyTotalsTable(HtmlPage page, int totalTests, int totalFailed, int totalSkipped, String totalPercents,
-			int totalCritical, int criticalFailed, String criticalPercents) {
+	private void verifyTotalsTable(HtmlPage page, int totalTests, int totalFailed, int totalSkipped, String totalPercents) {
 		HtmlTable table = page.getHtmlElementById("robot-summary-table");
 		String expectedTable = "<tableclass=\"table\"id=\"robot-summary-table\"><tbody><tr><th/><th>Total</th><th>Failed</th><th>Passed</th><th>Skipped</th><th>Pass%</th></tr>"
 				+ "<tr><th>Alltests</th><tdstyle=\"border-left:0px;\">" + totalTests + "</td>"

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -31,7 +31,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RobotPublisherTest {
-	private final boolean onlyCritical = false;
 	private final boolean countSkipped = false;
 
 	@Before
@@ -39,7 +38,7 @@ public class RobotPublisherTest {
 	}
 
 	private RobotPublisher getRobotPublisher(double passThreshold, double unstableThreshold) {
-		return new RobotPublisher(null, "", "", false, "", "", passThreshold, unstableThreshold, onlyCritical, countSkipped, "", false, "");
+		return new RobotPublisher(null, "", "", false, "", "", passThreshold, unstableThreshold,  countSkipped, "", false, "");
 	}
 
 	@Test
@@ -58,7 +57,7 @@ public class RobotPublisherTest {
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
-		when(mockResult.getPassPercentage(onlyCritical)).thenReturn(100.0);
+		when(mockResult.getPassPercentage(countSkipped)).thenReturn(100.0);
 
 		Assert.assertEquals(Result.SUCCESS, publisher.getBuildResult(mockBuild, mockResult));
 	}
@@ -70,7 +69,7 @@ public class RobotPublisherTest {
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.FAILURE);
-		when(mockResult.getPassPercentage(onlyCritical)).thenReturn(100.0);
+		when(mockResult.getPassPercentage(countSkipped)).thenReturn(100.0);
 
 		Assert.assertEquals(Result.FAILURE, publisher.getBuildResult(mockBuild, mockResult));
 	}
@@ -82,7 +81,7 @@ public class RobotPublisherTest {
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
-		when(mockResult.getPassPercentage(onlyCritical)).thenReturn(49.9);
+		when(mockResult.getPassPercentage(countSkipped)).thenReturn(49.9);
 
 		Assert.assertEquals(Result.FAILURE, publisher.getBuildResult(mockBuild, mockResult));
 	}
@@ -94,7 +93,7 @@ public class RobotPublisherTest {
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
-		when(mockResult.getPassPercentage(onlyCritical)).thenReturn(89.9);
+		when(mockResult.getPassPercentage(countSkipped)).thenReturn(89.9);
 
 		Assert.assertEquals(Result.UNSTABLE, publisher.getBuildResult(mockBuild, mockResult));
 	}
@@ -106,7 +105,7 @@ public class RobotPublisherTest {
 		AbstractBuild<?,?> mockBuild = mock(FreeStyleBuild.class);
 
 		when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
-		when(mockResult.getPassPercentage(onlyCritical)).thenReturn(90.0);
+		when(mockResult.getPassPercentage(countSkipped)).thenReturn(90.0);
 
 		Assert.assertEquals(Result.SUCCESS, publisher.getBuildResult(mockBuild, mockResult));
 	}

--- a/src/test/java/hudson/plugins/robot/graph/RobotGraphHelperTest.java
+++ b/src/test/java/hudson/plugins/robot/graph/RobotGraphHelperTest.java
@@ -67,28 +67,28 @@ public class RobotGraphHelperTest extends TestCase {
 
 	public void testShouldLimitResultsGraphDataSet() throws Exception {
 		RobotGraph limitedResultsGraph = RobotGraphHelper.createTestResultsGraphForTestObject(
-				mockResult2, false, false, false, false, false, xLabelFormat,1);
+				mockResult2, false, false, false, false, xLabelFormat,1);
 
 		assertEquals(1, limitedResultsGraph.getDataset().getColumnCount());
 	}
 
 	public void testShouldReturnAllResultsGraphDataIfNotLimited() throws Exception {
 		RobotGraph notlimitedResultsGraph = RobotGraphHelper.createTestResultsGraphForTestObject(
-				mockResult2, false, false, false, false, false, xLabelFormat,0);
+				mockResult2, false, false, false, false, xLabelFormat,0);
 
 		assertEquals(2, notlimitedResultsGraph.getDataset().getColumnCount());
 	}
 
 	public void testShouldReturnAllResultsGraphDataIfLimitIsBiggerThanDataAmount() throws Exception {
 		RobotGraph notlimitedResultsGraph = RobotGraphHelper.createTestResultsGraphForTestObject(
-				mockResult2, false, false, false, false, false, xLabelFormat,10);
+				mockResult2, false, false, false, false, xLabelFormat,10);
 
 		assertEquals(2, notlimitedResultsGraph.getDataset().getColumnCount());
 	}
 
 	public void testShouldShowCustomLabel() throws Exception {
 		RobotGraph customLabelGraph = RobotGraphHelper.createTestResultsGraphForTestObject(
-				mockResult2, false, false, false, false, false, "$display_name",0);
+				mockResult2, false, false, false, false, "$display_name",0);
 
 		assertEquals("3.2.1", customLabelGraph.getDataset().getColumnKey(0).toString());
 		assertEquals("1.2.3", customLabelGraph.getDataset().getColumnKey(1).toString());

--- a/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
+++ b/src/test/java/hudson/plugins/robot/model/RobotResultTest.java
@@ -93,14 +93,6 @@ public class RobotResultTest {
 		assertNotNull(result.getSuite("Somecases_1"));
 	}
 
-	@Deprecated
-	@Test
-	@Ignore
-        // TODO: remove test when criticality is removed
-	public void testShouldParseCriticalCases(){
-		assertEquals(19, result.getCriticalTotal());
-	}
-
 	@Test
 	public void testShouldParseFailMessages(){
 		RobotSuiteResult suite = result.getSuite("Othercases & Testcases");
@@ -108,19 +100,6 @@ public class RobotResultTest {
 		RobotCaseResult caseResult = childSuite.getCase("Failer");
 		String errorMsg = caseResult.getErrorMsg();
 		assertEquals("Test failed miserably!", errorMsg.trim());
-	}
-
-	@Deprecated
-	@Test
-	@Ignore
-	// TODO: remove test when criticality is removed
-	public void testShouldParseNewCriticalCases() throws Exception{
-
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
-		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
-		result.tally(null);
-
-		assertEquals(14, result.getCriticalTotal());
 	}
 
 	@Test
@@ -131,25 +110,6 @@ public class RobotResultTest {
 	@Test
 	public void testShouldParseFailedCases(){
 		assertEquals(10, result.getOverallFailed());
-	}
-
-	@Deprecated
-	@Test
-	@Ignore
-	public void testShouldParseFailedCriticalCases(){
-		assertEquals(9, result.getCriticalFailed());
-	}
-
-	@Deprecated
-	@Test
-	@Ignore
-	// TODO: remove test when criticality is removed
-	public void testShouldParseFailedNewCriticalCases() throws Exception{
-		RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
-		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
-		result.tally(null);
-
-		assertEquals(7, result.getCriticalFailed());
 	}
 
 	@Test
@@ -201,18 +161,6 @@ public class RobotResultTest {
 		RobotCaseResult caseResult = subSuite.getCase("Example test 2");
 
 		assertEquals("s1-s1-t2", caseResult.getId());
-	}
-
-	@Test
-	public void testShouldParseCriticalityFromStatusInsteadOfTest() throws Exception{
-		 RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable("new_critical_output.xml", null, null);
-		result = remoteOperation.invoke(new File(RobotSuiteResultTest.class.getResource("new_critical_output.xml").toURI()).getParentFile(), null);
-		result.tally(null);
-
-		RobotSuiteResult suite = result.getSuite("Othercases & Testcases");
-		RobotCaseResult caseResult = suite.getCase("Hello");
-
-		assertFalse("Case shouldn't be critical", caseResult.isCritical());
 	}
 
 	@Test

--- a/src/test/java/hudson/plugins/robot/tokens/RobotFailTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotFailTokenMacroTest.java
@@ -34,13 +34,7 @@ public class RobotFailTokenMacroTest extends TestCase {
 		assertTrue(token.acceptsMacroName(macroName));
 	}
 
-	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = true;
-		assertEquals("6",token.evaluate(build, listener, macroName));
-	}
-
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = false;
 		assertEquals("6",token.evaluate(build, listener, macroName));
 	}
 }

--- a/src/test/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotPassPercentageTokenMacroTest.java
@@ -39,12 +39,6 @@ public class RobotPassPercentageTokenMacroTest extends TestCase {
 		assertTrue(new RobotPassPercentageTokenMacro().acceptsMacroName(macroName));
 	}
 	
-	// TODO: remove test when criticality is removed
-	public void testTokenConversionWithOnlyCritical() throws MacroEvaluationException, IOException, InterruptedException{
-		token.countSkippedTests = true;
-		assertEquals("55.0",token.evaluate(build, listener, macroName));
-	}
-	
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{
 		token.countSkippedTests = false;
 		assertEquals("41.0",token.evaluate(build, listener, macroName));

--- a/src/test/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotPassRatioTokenMacroTest.java
@@ -37,14 +37,7 @@ public class RobotPassRatioTokenMacroTest extends TestCase {
 		assertTrue(new RobotPassRatioTokenMacro().acceptsMacroName(macroName));
 	}
 
-        // TODO: remove test when criticality is removed
-	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = true;
-		assertEquals("6 / 13",token.evaluate(build, listener, macroName));
-	}
-
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = false;
 		assertEquals("6 / 13",token.evaluate(build, listener, macroName));
 	}
 }

--- a/src/test/java/hudson/plugins/robot/tokens/RobotPassTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotPassTokenMacroTest.java
@@ -34,14 +34,7 @@ public class RobotPassTokenMacroTest extends TestCase {
 		assertTrue(token.acceptsMacroName(macroName));
 	}
 
-// TODO: remove test when criticality is removed
-	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = true;
-		assertEquals("6",token.evaluate(build, listener, macroName));
-	}
-
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = false;
 		assertEquals("6",token.evaluate(build, listener, macroName));
 	}
 }

--- a/src/test/java/hudson/plugins/robot/tokens/RobotTotalTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/robot/tokens/RobotTotalTokenMacroTest.java
@@ -34,13 +34,7 @@ public class RobotTotalTokenMacroTest extends TestCase {
 		assertTrue(token.acceptsMacroName(macroName));
 	}
 
-	public void testTokenConversionWithCritical() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = true;
-		assertEquals("6",token.evaluate(build, listener, macroName));
-	}
-
 	public void testTokenConversionWithAll() throws MacroEvaluationException, IOException, InterruptedException{
-		token.onlyCritical = false;
 		assertEquals("6",token.evaluate(build, listener, macroName));
 	}
 }


### PR DESCRIPTION
Drop all support for parsing test criticality. RF <4.0 is no longer officially supported.