### PR TITLE
add jdk21 support on windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 17],
     [platform: 'windows', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
This pull request adds jdk21 support on windows, because plugin is not working/not loading on windows with jdk21.

### Testing done

- All unit tests passed locally.
- The build passed and a new hpi file was created in Version6.0.1-SNAPSHOT (private-2efb50be-d.richter).
- I setup a local running Jenkins on windows with only jdk21 and installed the snapshot-hpi file.
- I configured a new test-job running some robot tests to generate some output.xml and robot logs.
- Then i checked, if plugin is correctly processing the robot logs. => all is fine.
- Results and Trend graph is shown correctly.

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
