### PR TITLE
JENKINS-75980 : Add Skipped Tests results in a separate section in the Browse Results Screen

### DIFF
--- a/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
@@ -54,6 +54,7 @@ public class RobotCaseResult extends RobotTestObject{
 
 	private RobotSuiteResult parent;
 	private int failedSince;
+	private int skippedSince;
 
 	/**
 	 * Difference between string timevalues in format yyyyMMdd HH:mm:ss.SS (Java DateFormat).
@@ -232,6 +233,24 @@ public class RobotCaseResult extends RobotTestObject{
 		return failedSince;
 	}
 
+	public int getSkippedSince() {
+		if (skippedSince == 0 && isSkipped()) {
+			RobotCaseResult previous = getPreviousResult();
+			if(previous != null && previous.isSkipped())
+				this.skippedSince = previous.getSkippedSince();
+			else if (getOwner() != null) {
+				this.skippedSince = getOwner().getNumber();
+			} else {
+				LOGGER.warn("trouble calculating getSkippedSince. We've got prev, but no owner.");
+			}
+		}
+		return skippedSince;
+	}
+
+	public void setSkippedSince(int skippedSince) {
+		this.skippedSince = skippedSince;
+	}
+
 	public void setFailedSince(int failedSince) {
 		this.failedSince = failedSince;
 	}
@@ -259,14 +278,24 @@ public class RobotCaseResult extends RobotTestObject{
 	}
 
 	/**
-	 * Get the number of builds this test case has failed for
+	 * Gives the run that this case first skipped in
+	 * @return run object
+	 */
+	public Run<?,?> getSkippedSinceRun() {
+		return getOwner().getParent().getBuildByNumber(getSkippedSince());
+	}
+
+	/**
+	 * Get the number of builds this test case has failed/skipped for
 	 * @return number of builds
 	 */
 	public int getAge(){
 		if(isPassed()) return 0;
 		Run<?,?> owner = getOwner();
-		if(owner != null)
-			return getOwner().getNumber() - getFailedSince() + 1;
+		if(owner != null) {
+			int previousStatusBuild = isSkipped() ? getSkippedSince() : getFailedSince();
+			return getOwner().getNumber() - previousStatusBuild + 1;
+		}
 		else return 0;
 	}
 

--- a/src/main/resources/hudson/plugins/robot/model/RobotResult/index.jelly
+++ b/src/main/resources/hudson/plugins/robot/model/RobotResult/index.jelly
@@ -68,6 +68,9 @@ limitations under the License.
       <div style="margin-bottom=20px;">
         <u:failedCases />
       </div>
+      <div style="margin-bottom=20px;">
+        <u:skippedCases />
+      </div>
 
       <h2>Test Suites</h2>
       <table class="pane sortable">

--- a/src/main/resources/hudson/plugins/robot/model/RobotSuiteResult/index.jelly
+++ b/src/main/resources/hudson/plugins/robot/model/RobotSuiteResult/index.jelly
@@ -100,6 +100,9 @@ limitations under the License.
           <div style="margin-bottom=20px;">
           <u:failedCases />
           </div>
+          <div style="margin-bottom=20px;">
+              <u:skippedCases />
+          </div>
       <h2>Nested Test Suites</h2>
       <table class="pane sortable">
       <tr>

--- a/src/main/resources/hudson/plugins/robot/util/skippedCases.jelly
+++ b/src/main/resources/hudson/plugins/robot/util/skippedCases.jelly
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:u="/util">
+    <script src="${rootURL}/plugin/robot/robot.js"/>
+    <j:if test="${!it.allSkippedCases.isEmpty()}">
+        <style>
+            td.pane {
+                vertical-align: top;
+            }
+        </style>
+        <h2>Skipped Test Cases</h2>
+        <table class="pane sortable">
+            <tr>
+                <td class="pane-header" title="Test case name. Click to sort.">Name</td>
+                <td class="pane-header" title="Duration. Click to sort.">Duration</td>
+                <td class="pane-header" style="text-align:center;" title="Number of skipped builds. Click to sort.">Age</td>
+            </tr>
+            <j:forEach var="case" items="${it.allSkippedCases}">
+                <j:set var="fullName" value="${case.getRelativePackageName(it)}" />
+                <j:set var="relativeId" value="${case.getRelativeId(it)}" />
+                <j:set var="escapedName" value="${h.escape(fullName)}" />
+                <tr>
+                    <td class="pane">
+                        <a id="${escapedName}-showlink" href="#" class="robot-expand" data-escaped-name="${escapedName}" data-relative-id="${relativeId}/summary"></a>
+                        <a id="${escapedName}-hidelink" href="#" style="display:none" class="robot-collapse" data-escaped-name="${escapedName}"></a>
+                        <st:nbsp/>
+                        <a href="${relativeId}"><small>${case.getRelativeParent(it)}</small>${case.name}</a>
+                        <div id="${escapedName}" class="hidden" style="display:none">
+                            ${%Loading...}
+                        </div>
+                    </td>
+                    <td class="pane">${case.humanReadableDuration}</td>
+                    <td class="pane" style="text-align:center;">
+                        <j:if test="${case.skippedSinceRun != null}">
+                            <a href="${rootURL}/${case.skippedSinceRun.url}">${case.age}</a>
+                        </j:if>
+                        <j:if test="${case.skippedSinceRun == null}">
+                            ${case.age}
+                        </j:if>
+                    </td>
+                </tr>
+            </j:forEach>
+        </table>
+    </j:if>
+</j:jelly>


### PR DESCRIPTION
Added Skipped Results in a separate section in the Browse Results Screen. This includes display of "Age" for the skipped tests. This issue was raised under [ JENKINS-75980 : Add Skipped Tests results in a separate section in the Browse Results Screen](https://issues.jenkins.io/browse/JENKINS-75980)

### Testing done
Before Changes:
<img width="798" height="494" alt="image" src="https://github.com/user-attachments/assets/bb2bd39d-db34-40bd-b6b7-cb268dbbe435" />


After Changes:
<img width="798" height="494" alt="image" src="https://github.com/user-attachments/assets/37bf6b7b-4859-409e-8f22-7cf0ea056690" />

- This was tested with creating a pipeline job that parses an output.xml at the end, this test contained skipped test and we verified the age and the listing of the same on the browse page

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
