### PR TITLE
JENKINS-76150 - Check for empty string before parsing endtime

### DIFF
--- a/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotCaseResult.java
@@ -118,12 +118,14 @@ public class RobotCaseResult extends RobotTestObject{
 			return duration;
 		if (elapsedtime != 0)
 			return Double.valueOf(elapsedtime * 1000).longValue(); // convert seconds to milliseconds
-		try{
-			return timeDifference(this.starttime, this.endtime);
-		} catch (ParseException e){
-			LOGGER.warn("Couldn't parse duration for test case " + name);
-			return 0;
+		if (StringUtils.isNotEmpty(this.endtime)) {
+			try {
+				return timeDifference(this.starttime, this.endtime);
+			} catch (ParseException e) {
+				LOGGER.warn("Couldn't parse duration for test case " + name);
+			}
 		}
+		return 0;
 	}
 
 	public String getStarttime() {


### PR DESCRIPTION
`elapsedtime != 0` is not a conclusive test to determine whether we are converting the older version of the data file (without `elapsedtime`, which defaults to `0` when the `@CheckForNull` annotation is absent) or the newer version where `elapsedtime` just happens to be `0`. In the latter case, we should not attempt to parse `endtime`, since it will be empty and will cause an error to be logged. This commit adds this check.