### PR TITLE
fix for JENKINS-15190: use a default of 10 maxBuildsToShow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .DS_Store
 *.iml
 /work/
+.vscode

--- a/src/main/resources/hudson/plugins/robot/AggregatedRobotAction/index.jelly
+++ b/src/main/resources/hudson/plugins/robot/AggregatedRobotAction/index.jelly
@@ -24,8 +24,8 @@ limitations under the License.
                 <div style="border: 1px solid gray; margin-bottom: 20px; padding: 10px" >
                 <h2>Configuration: ${run.parent.displayName}</h2>
                 <div style="float:right">
-                <a href="${run.project.absoluteUrl}${run.number}/robot"><img title="Browse results" src="${run.project.absoluteUrl}${run.number}/robot/graph?zoomSignificant=true&amp;failedOnly=false&amp;maxBuildsToShow=0" width="500" height="200"/></a><br/>
-                <p style="float:right"><a href="graph?hd=true&amp;zoomSignificant=true&amp;failedOnly=false&amp;maxBuildsToShow=0">Show bigger image</a></p>
+                <a href="${run.project.absoluteUrl}${run.number}/robot"><img title="Browse results" src="${run.project.absoluteUrl}${run.number}/robot/graph?zoomSignificant=true&amp;failedOnly=false&amp;maxBuildsToShow=10" width="500" height="200"/></a><br/>
+                <p style="float:right"><a href="graph?hd=true&amp;zoomSignificant=true&amp;failedOnly=false&amp;maxBuildsToShow=10">Show bigger image</a></p>
                 </div>
                 <u:robotsummary action="${it.getChildBuildAction(run)}"/>
                 <div style="clear: both" />

--- a/src/main/webapp/robot.js
+++ b/src/main/webapp/robot.js
@@ -1,7 +1,7 @@
 function initPassFailGraph(target) {
     var mode = getCookie("RobotResult_zoom", "true");
     var failedOnly = getCookie("RobotResult_failedOnly", "false");
-    var maxBuildsToShow = getCookie("RobotResult_maxBuildsToShow", 0);
+    var maxBuildsToShow = getCookie("RobotResult_maxBuildsToShow", 10);
     if (document.getElementById("zoomToChanges"))
         document.getElementById("zoomToChanges").checked = (mode == "true");
     if (document.getElementById("failedOnly"))
@@ -11,7 +11,7 @@ function initPassFailGraph(target) {
 }
 
 function initDurationGraph(target) {
-    var maxBuildsToShow = getCookie("RobotResult_maxBuildsToShow", 0);
+    var maxBuildsToShow = getCookie("RobotResult_maxBuildsToShow", 10);
     setDurationGraphSrc(target, maxBuildsToShow);
 }
 

--- a/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherSystemTest.java
@@ -347,7 +347,7 @@ class RobotPublisherSystemTest {
         assertTextPresent(page, "Hello, world! != Good bye, world!");
         assertTextPresent(page, "0:00:00.001 (+0:00:00.001)");
         assertElementPresentByXPath(page,
-                "//div[@id='main-panel']//img[@src='durationGraph?maxBuildsToShow=0']");
+                "//div[@id='main-panel']//img[@src='durationGraph?maxBuildsToShow=10']");
 
         page = wc.goTo("job/robot/1/robot/Testcases%20&%20Othercases/Othercases/Contains%20string");
         assertTextPresent(page, "PASS");


### PR DESCRIPTION
As written in [JENKINS-15190](https://issues.jenkins.io/browse/JENKINS-15190) the computation of charts takes much time when **all** builds are considered. There is no global parameter, which overwrites MaxBuilds settings per project. Thus you must edit the value on every project e.g. jenkins-base-url/job/testjob/ and also on every robot results page e.g. jenkins-base-url/job/testjob/123/robot in order to overcome the problem. If there are already many jobs, then this is not possible (image generation runs into timeout). The current default of maxBuildsToShow was **0**, which means **all** build will be analyzed. In this Pull Request i suggest to change this default to **10**.

### Testing done

Local unit tests passed. Build succeed. Upload to a local Jenkins Instance was done and tested well.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch! => no need due to minimal change
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
