### PR TITLE
Add a lenient xml reader

### DIFF
--- a/src/main/java/hudson/plugins/robot/RecoveringXMLStreamReader.java
+++ b/src/main/java/hudson/plugins/robot/RecoveringXMLStreamReader.java
@@ -1,0 +1,133 @@
+package hudson.plugins.robot;
+
+import jenkins.util.SystemProperties;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.util.StreamReaderDelegate;
+
+import java.io.StringReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Set;
+
+/**
+ * An XMLStreamReader for an output file that cannot be read to its end. After
+ * the wrapped reader throws, the events come from a generated document that
+ * closes every open element, so the parser finishes the same way the parser
+ * finishes a complete file.
+ */
+class RecoveringXMLStreamReader extends StreamReaderDelegate {
+
+	/**
+	 * The Robot output XML schema requires suite, test and kw elements to have
+	 * a nested status element.
+	 */
+	private static final Set<String> HAS_STATUS = Set.of("suite", "test", "kw");
+
+	/** The system property that turns recovery on. */
+	static final String RECOVER_PARTIAL_OUTPUT = "hudson.plugins.robot.recoverPartialOutput";
+
+	private final Deque<String> elementStack = new ArrayDeque<>();
+	private int stoppedAfter;
+	private String parseError;
+
+	private boolean recoveryTried;
+
+	static String parseError(XMLStreamReader reader) {
+		return reader instanceof RecoveringXMLStreamReader recovering ? recovering.parseError : null;
+	}
+
+	static XMLStreamReader recovering(XMLStreamReader reader) {
+		return SystemProperties.getBoolean(RECOVER_PARTIAL_OUTPUT, false)
+				? new RecoveringXMLStreamReader(reader) : reader;
+	}
+
+	private RecoveringXMLStreamReader(XMLStreamReader reader) {
+		super(reader);
+	}
+
+	@Override
+	public int next() throws XMLStreamException {
+		int event;
+		try {
+			event = super.next();
+		} catch (XMLStreamException stopped) {
+			setParent(endingReader(stopped));
+			event = super.next();
+		}
+		track(event);
+		return event;
+	}
+
+	private void track(int event) {
+		stoppedAfter = event;
+		if (event == START_ELEMENT)
+			elementStack.push(super.getLocalName());
+		else if (event == END_ELEMENT)
+			elementStack.pop();
+	}
+
+	/**
+	 * When no element is open there is nothing to close, so the exception is
+	 * rethrown. When recovery was already tried, the exception comes from reading
+	 * the donor document, and recovering again would loop, so the exception is
+	 * rethrown.
+	 */
+	private XMLStreamReader endingReader(XMLStreamException stopped) throws XMLStreamException {
+		if (elementStack.isEmpty() || recoveryTried)
+			throw stopped;
+		recoveryTried = true;
+		parseError = "could not be read to the end: " + stopped.getMessage();
+		XMLStreamReader donor = XMLInputFactory.newInstance()
+				.createXMLStreamReader(new StringReader(endingDonor()));
+		for (String element : elementStack)
+			donor.nextTag();
+		return donor;
+	}
+
+	/**
+	 * An XML reader reports an end element only after the matching start
+	 * element, so the document opens every open element again before closing
+	 * the element. The closing tags are the end elements the parser still needs
+	 * to finish parsing the file.
+	 */
+	private String endingDonor() {
+		return openingTags() + lineEndAfterClose() + closingTags();
+	}
+
+	/** Robot writes a line end after every closing tag. */
+	private String lineEndAfterClose() {
+		return stoppedAfter == END_ELEMENT ? "\n" : "";
+	}
+
+	private String openingTags() {
+		StringBuilder xml = new StringBuilder();
+		for (String element : (Iterable<String>) elementStack::descendingIterator)
+			xml.append("<" + element + ">");
+		return xml.toString();
+	}
+
+	private String closingTags() {
+		StringBuilder xml = new StringBuilder();
+		for (String element : elementStack) {
+			if (HAS_STATUS.contains(element))
+				xml.append(statusElement());
+			//Robot writes a line end after every closing tag
+			xml.append("</" + element + ">\n");
+		}
+		return xml.toString();
+	}
+
+	private String statusElement() {
+		//Robot Framework 7 names the attribute elapsed and older versions name the attribute elapsedtime.
+		//The donor does not know the schema version.
+		return "<status status='FAIL' elapsed='0' elapsedtime='0'>" + escaped(parseError) + "</status>";
+	}
+
+	/** The parser message can name an element in angle brackets. */
+	private static String escaped(String text) {
+		return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+	}
+}

--- a/src/main/java/hudson/plugins/robot/RobotParser.java
+++ b/src/main/java/hudson/plugins/robot/RobotParser.java
@@ -61,6 +61,7 @@ public class RobotParser {
 		private final String reportFileName;
 
 		private int schemaVersion;
+		private final List<String> parseErrors = new ArrayList<>();
 		private String startLocalName = "starttime";
 		private String elapsedLocalName = "elapsedtime";
 		private String endLocalName = "endtime";
@@ -99,9 +100,10 @@ public class RobotParser {
 				if(dirFromFileGLOB != null)
 					baseDirectory = new File(baseDirectory, dirFromFileGLOB);
                 try (FileInputStream inputStream = new FileInputStream(reportFile)) {
-                    XMLStreamReader reader = factory.createXMLStreamReader(inputStream, "UTF-8");
+                    XMLStreamReader reader = RecoveringXMLStreamReader.recovering(factory.createXMLStreamReader(inputStream, "UTF-8"));
                     try {
                         parseResult(result, reader, baseDirectory);
+                        collectParseError(file, reader);
                     } finally {
                         reader.close();
                     }
@@ -109,7 +111,14 @@ public class RobotParser {
                     throw new IOException("Parsing of output xml failed!", e1);
                 }
 			}
+			result.setParseError(parseErrors.isEmpty() ? null : String.join("\n", parseErrors));
 			return result;
+		}
+
+		private void collectParseError(String file, XMLStreamReader reader) {
+			String message = RecoveringXMLStreamReader.parseError(reader);
+			if (message != null)
+				parseErrors.add(file + " " + message);
 		}
 
 		private RobotResult parseResult(RobotResult result, XMLStreamReader reader, File baseDirectory) throws XMLStreamException, IOException {
@@ -197,12 +206,14 @@ public class RobotParser {
 			XMLInputFactory factory = XMLInputFactory.newInstance();
 			factory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
             try (FileInputStream inputStream = new FileInputStream(new File(baseDirectory, path))) {
-                XMLStreamReader splitReader = factory.createXMLStreamReader(inputStream, "UTF-8");
+                XMLStreamReader splitReader = RecoveringXMLStreamReader.recovering(factory.createXMLStreamReader(inputStream, "UTF-8"));
                 try {
                     while (splitReader.hasNext()) {
                         splitReader.next();
                         if (splitReader.isStartElement() && "suite".equals(splitReader.getLocalName())) {
-                            return processSuite(splitReader, parent, baseDirectory);
+                            RobotSuiteResult suite = processSuite(splitReader, parent, baseDirectory);
+                            collectParseError(path, splitReader);
+                            return suite;
                         }
                     }
                     throw xmlException("Illegal split xml output. Could not find suite element.", splitReader);

--- a/src/main/java/hudson/plugins/robot/RobotPublisher.java
+++ b/src/main/java/hudson/plugins/robot/RobotPublisher.java
@@ -292,6 +292,8 @@ public class RobotPublisher extends Recorder implements Serializable,
 
                 result = parse(expandedOutputFileName, expandedLogFileName, expandedReportFileName, expandedOutputPath, build, workspace, launcher, listener);
                 logger.println(Messages.robot_publisher_done());
+                if (result.getParseError() != null)
+                    logger.println(Messages.robot_publisher_parse_error() + " " + result.getParseError());
 
                 // Check if log and report files exist
                 FilePath outputDir = new FilePath(workspace, expandedOutputPath);
@@ -493,6 +495,10 @@ public class RobotPublisher extends Recorder implements Serializable,
     protected Result getBuildResult(Run<?, ?> build,
                                     RobotResult result) {
         if (build.getResult() != Result.FAILURE) {
+            //the test counts are incomplete when a file was not read to the end
+            if (result.getParseError() != null) {
+                return Result.FAILURE;
+            }
             double passPercentage = result.getPassPercentage(countSkippedTests);
             if (passPercentage < getUnstableThreshold()) {
                 return Result.FAILURE;

--- a/src/main/java/hudson/plugins/robot/model/RobotResult.java
+++ b/src/main/java/hudson/plugins/robot/model/RobotResult.java
@@ -53,6 +53,8 @@ public class RobotResult extends RobotTestObject {
 
 	private String timeStamp;
 
+	private String parseError;
+
 	private transient int passed, failed, skipped;
 
 	//backwards compatibility with old builds
@@ -155,6 +157,22 @@ public class RobotResult extends RobotTestObject {
 	 */
 	public void setTimeStamp(String timeStamp) {
 		this.timeStamp = timeStamp;
+	}
+
+	/**
+	 * One line for each output file that could not be read to the end, each line
+	 * being the file name followed by the parser message. Null when every file
+	 * was read to the end. The results from a file that was not read to the end
+	 * do not include the tests after the point where reading stopped.
+	 * @return the parse errors, or null
+	 */
+	@Exported
+	public String getParseError() {
+		return parseError;
+	}
+
+	public void setParseError(String parseError) {
+		this.parseError = parseError;
 	}
 
 	/**

--- a/src/main/resources/hudson/plugins/robot/Messages.properties
+++ b/src/main/resources/hudson/plugins/robot/Messages.properties
@@ -24,6 +24,7 @@ robot.publisher.done= Done!
 robot.publisher.fail= Failed!
 
 robot.publisher.file_not_found=WARNING! Could not find file:
+robot.publisher.parse_error=ERROR! Could not read all of the results:
 
 robot.config.percentvalidation=Entry must be percentage value between 0-100
 

--- a/src/test/java/hudson/plugins/robot/RobotParserTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotParserTest.java
@@ -1,12 +1,37 @@
 package hudson.plugins.robot;
 
+import hudson.plugins.robot.model.RobotResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RobotParserTest {
+
+    @BeforeEach
+    void turnRecoveryOn() {
+        System.setProperty(RecoveringXMLStreamReader.RECOVER_PARTIAL_OUTPUT, "true");
+    }
+
+    @AfterEach
+    void leaveTheDefaultAsItIs() {
+        System.clearProperty(RecoveringXMLStreamReader.RECOVER_PARTIAL_OUTPUT);
+    }
 
     @Test
     void testBasic1() {
@@ -202,11 +227,149 @@ class RobotParserTest {
         parse(dir, mask);
     }
 
-    private void parse(String dir, String mask) {
-        assertDoesNotThrow(() -> {
+    @Test
+    void testTruncatedOutput() {
+        final String dir = ".";
+        final String mask = "truncated_output.xml";
+        RobotResult result = parse(dir, mask);
+        result.tally(null);
+        assertEquals(2, result.getOverallTotal());
+        assertEquals(1, result.getOverallPassed());
+        assertEquals(1, result.getOverallFailed());
+        assertEquals("Crashed Test", result.getAllFailedCases().get(0).getName());
+        assertNotNull(result.getParseError());
+    }
+
+    @Test
+    void testTruncatedBetweenTests() {
+        final String dir = ".";
+        final String mask = "truncated_between_tests_output.xml";
+        RobotResult result = parse(dir, mask);
+        result.tally(null);
+        assertEquals(1, result.getOverallTotal());
+        assertEquals(1, result.getOverallPassed());
+        assertEquals(0, result.getOverallFailed());
+        assertNotNull(result.getParseError());
+    }
+
+    /** Robot fails every test in a suite whose teardown fails. */
+    @Test
+    void testTruncatedSuiteTeardown() {
+        final String dir = ".";
+        final String mask = "truncated_teardown_output.xml";
+        RobotResult result = parse(dir, mask);
+        result.tally(null);
+        assertEquals(1, result.getOverallTotal());
+        assertEquals(0, result.getOverallPassed());
+        assertEquals(1, result.getOverallFailed());
+        assertNotNull(result.getParseError());
+    }
+
+    /** The pass percentage of zero tests is 100, so the parse error is the only thing that fails the build. */
+    @Test
+    void testTruncatedBeforeFirstSuite() {
+        final String dir = ".";
+        final String mask = "truncated_before_suite_output.xml";
+        RobotResult result = parse(dir, mask);
+        result.tally(null);
+        assertEquals(0, result.getOverallTotal());
+        assertEquals(100, result.getPassPercentage(), 0.01);
+        assertNotNull(result.getParseError());
+    }
+
+    /**
+     * The truncation points include the middle of multi-byte characters and
+     * the middle of entities. This file contains failing tests.
+     */
+    @Test
+    void testEveryTruncationPoint(@TempDir Path workspace) throws Exception {
+        sweep(workspace, "rebot_output.xml");
+    }
+
+    /** Every test in this file passed, so a parse error is the only failure a truncated copy can report. */
+    @Test
+    void testEveryTruncationPointOfPassingRun(@TempDir Path workspace) throws Exception {
+        sweep(workspace, "robot7/inline_var_output.xml");
+    }
+
+    @Test
+    void testEveryTruncationPointOfNestedRun(@TempDir Path workspace) throws Exception {
+        sweep(workspace, "model/output.xml");
+    }
+
+    /**
+     * XMLStreamReader implementations differ in when they report the text of an
+     * element, so this test is worth running with more than one. The test
+     * classpath provides Woodstox. Jenkins provides the JDK implementation
+     * unless the woodstox-core-api plugin is installed. Run with
+     * -Djavax.xml.stream.XMLInputFactory=com.sun.xml.internal.stream.XMLInputFactoryImpl
+     * to test the JDK implementation.
+     * <p>
+     * Before the end of the robot start tag no element has been read, so parsing
+     * must throw. The parser stops reading at the statistics element, so a
+     * truncation after the statistics start tag has no parse error. A longer
+     * truncation contains every complete test of a shorter one, so the number of
+     * reported tests cannot decrease.
+     */
+    private void sweep(Path workspace, String resource) throws Exception {
+        byte[] whole = Files.readAllBytes(Path.of(RobotParserTest.class.getResource(resource).toURI()));
+        //ISO-8859-1 maps each byte to one char, so an offset in text is the same offset in whole
+        String text = new String(whole, StandardCharsets.ISO_8859_1);
+        int readable = text.indexOf('>', text.indexOf("<robot")) + 1;
+        int complete = text.indexOf("<statistics>") + "<statistics>".length();
+        List<String> broken = new ArrayList<>();
+        long reported = 0;
+        for (int length = 0; length <= whole.length; length++) {
+            Files.write(workspace.resolve("output.xml"), Arrays.copyOf(whole, length));
+            RobotParser.RobotParserCallable parser = new RobotParser.RobotParserCallable("output.xml", null, null);
+            try {
+                RobotResult result = parser.invoke(workspace.toFile(), null);
+                result.tally(null);
+                if (length < readable)
+                    broken.add(length + ": read as " + result.getOverallTotal() + " tests instead of failing");
+                else if (length < complete && result.getParseError() == null)
+                    broken.add(length + ": read short without saying so");
+                else if (length >= complete && result.getParseError() != null)
+                    broken.add(length + ": said it read short when it had not");
+                else if (result.getOverallTotal() < reported)
+                    broken.add(length + ": " + result.getOverallTotal() + " tests after " + reported + " were reported");
+                reported = Math.max(reported, result.getOverallTotal());
+            } catch (Exception failed) {
+                if (length >= readable)
+                    broken.add(length + ": " + failed.getCause());
+            }
+        }
+        assertTrue(broken.isEmpty(), () -> broken.size() + " of " + whole.length + " truncation points of "
+                + resource + " misbehave: " + String.join(" | ", broken.subList(0, Math.min(10, broken.size()))));
+    }
+
+    @Test
+    void testSplitSuiteReadShort() {
+        final String dir = ".";
+        final String mask = "truncated_split_output.xml";
+        RobotResult result = parse(dir, mask);
+        result.tally(null);
+        assertEquals(2, result.getOverallTotal());
+        assertEquals(1, result.getOverallPassed());
+        assertEquals(1, result.getOverallFailed());
+        assertEquals("Crashed Test", result.getAllFailedCases().get(0).getName());
+        assertTrue(result.getParseError().startsWith("truncated_split_output-001.xml"));
+    }
+
+    @Test
+    void testFileCutOffIsRefusedByDefault() throws Exception {
+        System.clearProperty(RecoveringXMLStreamReader.RECOVER_PARTIAL_OUTPUT);
+        File directory = new File(RobotParserTest.class.getResource(".").toURI());
+        RobotParser.RobotParserCallable remoteOperation =
+                new RobotParser.RobotParserCallable("truncated_output.xml", null, null);
+        assertThrows(IOException.class, () -> remoteOperation.invoke(directory, null));
+    }
+
+    private RobotResult parse(String dir, String mask) {
+        return assertDoesNotThrow(() -> {
             File directory = new File(RobotParserTest.class.getResource(dir).toURI());
             RobotParser.RobotParserCallable remoteOperation = new RobotParser.RobotParserCallable(mask, null, null);
-            remoteOperation.invoke(directory, null);
+            return remoteOperation.invoke(directory, null);
         });
     }
 }

--- a/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
+++ b/src/test/java/hudson/plugins/robot/RobotPublisherTest.java
@@ -66,6 +66,19 @@ class RobotPublisherTest {
     }
 
     @Test
+    void testShouldFailWhenResultsWereNotReadInFull() {
+        RobotPublisher publisher = getRobotPublisher(0, 0);
+        RobotResult mockResult = mock(RobotResult.class);
+        AbstractBuild<?, ?> mockBuild = mock(FreeStyleBuild.class);
+
+        when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
+        when(mockResult.getParseError()).thenReturn("Robot output file could not be read to the end: ...");
+        when(mockResult.getPassPercentage(countSkipped)).thenReturn(100.0);
+
+        assertEquals(Result.FAILURE, publisher.getBuildResult(mockBuild, mockResult));
+    }
+
+    @Test
     void testShouldFailWhenUnstableThresholdNotExceeded() {
         RobotPublisher publisher = getRobotPublisher(90, 50);
         RobotResult mockResult = mock(RobotResult.class);

--- a/src/test/resources/hudson/plugins/robot/truncated_before_suite_output.xml
+++ b/src/test/resources/hudson/plugins/robot/truncated_before_suite_output.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The missing end tags are intentional. -->
+<robot generator="Robot 7.0 (Python 3.11.4 on linux)" generated="2026-08-27T10:00:00.000000" rpa="false" schemaversion="5">
+<su

--- a/src/test/resources/hudson/plugins/robot/truncated_between_tests_output.xml
+++ b/src/test/resources/hudson/plugins/robot/truncated_between_tests_output.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The missing end tags are intentional. -->
+<robot generator="Robot 7.0 (Python 3.11.4 on linux)" generated="2026-08-27T10:00:00.000000" rpa="false" schemaversion="5">
+<suite id="s1" name="Truncated" source="/tmp/truncated/tests.robot">
+<test id="s1-t1" name="Completed Test" line="2">
+<kw name="Log" owner="BuiltIn">
+<arg>working</arg>
+<status status="PASS" start="2026-08-27T10:00:00.100000" elapsed="0.000100"/>
+</kw>
+<status status="PASS" start="2026-08-27T10:00:00.000000" elapsed="0.001000"/>
+</test>
+<te

--- a/src/test/resources/hudson/plugins/robot/truncated_output.xml
+++ b/src/test/resources/hudson/plugins/robot/truncated_output.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The missing end tags are intentional. -->
+<robot generator="Robot 7.0 (Python 3.11.4 on linux)" generated="2026-08-27T10:00:00.000000" rpa="false" schemaversion="5">
+<suite id="s1" name="Truncated" source="/tmp/truncated">
+<suite id="s1-s1" name="Tests" source="/tmp/truncated/tests.robot">
+<test id="s1-s1-t1" name="Completed Test" line="2">
+<kw name="Log" owner="BuiltIn">
+<arg>working</arg>
+<status status="PASS" start="2026-08-27T10:00:00.100000" elapsed="0.000100"/>
+</kw>
+<status status="PASS" start="2026-08-27T10:00:00.000000" elapsed="0.001000"/>
+</test>
+<test id="s1-s1-t2" name="Crashed Test" line="6">
+<kw name="Run Process" owner="Process">
+<arg>kill

--- a/src/test/resources/hudson/plugins/robot/truncated_split_output-001.xml
+++ b/src/test/resources/hudson/plugins/robot/truncated_split_output-001.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The missing end tags are intentional. -->
+<suite id="s1-s1" name="Part" source="/tmp/split/part.robot">
+<test id="s1-s1-t1" name="Completed Test" line="2">
+<kw name="Log" owner="BuiltIn">
+<arg>working</arg>
+<status status="PASS" start="2026-08-31T10:00:00.100000" elapsed="0.000100"/>
+</kw>
+<status status="PASS" start="2026-08-31T10:00:00.000000" elapsed="0.001000"/>
+</test>
+<test id="s1-s1-t2" name="Crashed Test" line="6">
+<kw name="Run Process" owner="Process">
+<arg>kill

--- a/src/test/resources/hudson/plugins/robot/truncated_split_output.xml
+++ b/src/test/resources/hudson/plugins/robot/truncated_split_output.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The split file named in the suite src attribute is deliberately incomplete. -->
+<robot generator="Robot 7.0 (Python 3.11.4 on linux)" generated="2026-08-31T10:00:00.000000" rpa="false" schemaversion="5">
+<suite id="s1" name="Split" source="/tmp/split">
+<suite src="truncated_split_output-001.xml" name="Part" source="/tmp/split/part.robot">
+<status status="PASS" start="2026-08-31T10:00:00.000000" elapsed="0.002000"/>
+</suite>
+<status status="PASS" start="2026-08-31T10:00:00.000000" elapsed="0.003000"/>
+</suite>
+<statistics>
+<total>
+<stat pass="2" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="2" fail="0" skip="0" id="s1" name="Split">Split</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/src/test/resources/hudson/plugins/robot/truncated_teardown_output.xml
+++ b/src/test/resources/hudson/plugins/robot/truncated_teardown_output.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The missing end tags are intentional. -->
+<robot generator="Robot 7.0 (Python 3.11.4 on linux)" generated="2026-08-27T10:00:00.000000" rpa="false" schemaversion="5">
+<suite id="s1" name="Truncated" source="/tmp/truncated/tests.robot">
+<test id="s1-t1" name="Completed Test" line="2">
+<kw name="Log" owner="BuiltIn">
+<arg>working</arg>
+<status status="PASS" start="2026-08-27T10:00:00.100000" elapsed="0.000100"/>
+</kw>
+<status status="PASS" start="2026-08-27T10:00:00.000000" elapsed="0.001000"/>
+</test>
+<kw name="Remove Directory" owner="OperatingSystem" type="TEARDOWN">
+<arg>/tmp/wor


### PR DESCRIPTION
Currently the plugin throws an exception and doesn't upload any files if robot output files fail to parse. Once in a while we have tests failing so bad that the output files are just cut off. This change introduces an opt-in xml reader that reports invalid xml as a failure, but preserves tests that have been parsed to that point.

### Testing done

Added some tests, ran in my environment.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
